### PR TITLE
feat: Swap to new SDK flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^17.0.20",
     "@types/react-dom": "^17.0.9",
-    "@uma/sdk": "^0.20.0",
+    "@uma/sdk": "^0.21.0",
     "bnc-onboard": "^1.37.0",
     "ethers": "^5.4.2",
     "framer-motion": "^5.5.6",

--- a/src/components/request/Request.tsx
+++ b/src/components/request/Request.tsx
@@ -13,7 +13,6 @@ import useClient from "hooks/useOracleClient";
 import useReader from "hooks/useOracleReader";
 import SettledTable from "./SettledTable";
 import dataIcon from "assets/data-icon.svg";
-import useOracleClient from "hooks/useOracleClient";
 /* Search Params:
   {
     requester: string;
@@ -25,12 +24,11 @@ import useOracleClient from "hooks/useOracleClient";
 */
 
 const Request = () => {
-  const { client, state } = useClient();
+  const { client, state, flags } = useClient();
   const [searchParams] = useSearchParams();
   const { rows, headerCells } = useRequestTableData(searchParams);
 
-  const { requestState, proposer, disputer, proposedPrice } = useReader(state);
-  const oracleContext = useOracleClient();
+  const { proposer, disputer, proposedPrice } = useReader(state);
 
   useEffect(() => {
     const requester = searchParams.get("requester")?.trim();
@@ -54,14 +52,12 @@ const Request = () => {
 
   return (
     <Wrapper>
-      {requestState !==
-        oracleContext.oracle.types.state.RequestState.Settled && (
+      {!flags.RequestSettled && (
         <RequestHero chainId={Number(searchParams.get("chainId")) ?? 0} />
       )}
 
       <TableSection>
-        {requestState ===
-          oracleContext.oracle.types.state.RequestState.Settled && (
+        {flags.RequestSettled && (
           <TableContentWrapper>
             <SettledTable
               proposer={proposer}

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -260,7 +260,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}/address/${proposer}`}
+                  href={`${explorerUrl}address/${proposer}`}
                 >
                   {proposer}
                 </a>
@@ -272,7 +272,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}/address/${disputer}`}
+                  href={`${explorerUrl}address/${disputer}`}
                 >
                   {disputer}
                 </a>

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -25,7 +25,6 @@ import useReader from "hooks/useOracleReader";
 import { ethers } from "ethers";
 import { prettyFormatNumber } from "helpers/format";
 import BouncingDotsLoader from "components/bouncing-dots-loader";
-import { oracle } from "@uma/sdk";
 
 const RequestForm: FC = () => {
   const [currentTime, setCurrentTime] = useState(0);
@@ -69,7 +68,6 @@ const RequestForm: FC = () => {
     proposedPrice,
     disputer,
     proposer,
-    requestState,
     explorerUrl,
   } = useReader(state);
 
@@ -188,10 +186,11 @@ const RequestForm: FC = () => {
           {buttonProps.label}
         </RequestFormButton>
       );
-    } else if (requestState === oracle.types.state.RequestState.Disputed) {
+    } else if (flags.InDvmVote) {
       return <RequestFormButton disabled={true}>Disputed</RequestFormButton>;
     } else {
-      return <RequestFormButton disabled={true}>Resolved</RequestFormButton>;
+      // TODO later: Settle functionality.
+      return <RequestFormButton disabled={true}>Settle</RequestFormButton>;
     }
   };
 
@@ -216,7 +215,7 @@ const RequestForm: FC = () => {
           <FormHeader>
             {flags.CanPropose && "Proposal"}
             {flags.CanDispute && "Dispute Period"}
-            {requestState === oracle.types.state.RequestState.Disputed && (
+            {flags.InDvmVote && (
               <>
                 <div>Proposal</div>
                 <div>
@@ -232,6 +231,7 @@ const RequestForm: FC = () => {
                 </div>
               </>
             )}
+            {flags.CanSettle && "Settle"}
           </FormHeader>
           <RequestFormInputWrapper>
             <RequestInputButtonBlock>
@@ -242,8 +242,7 @@ const RequestForm: FC = () => {
                   onChange={inputOnChange}
                 />
               )}
-              {(flags.CanDispute ||
-                requestState === oracle.types.state.RequestState.Disputed) &&
+              {(flags.CanDispute || flags.InDvmVote || flags.CanSettle) &&
                 proposedPrice && (
                   <RequestFormInput
                     disabled={true}
@@ -255,7 +254,7 @@ const RequestForm: FC = () => {
               {getButton(value)}
             </RequestInputButtonBlock>
             {inputError && <InputError>{inputError}</InputError>}
-            {flags.CanDispute && (
+            {(flags.CanDispute || flags.InDvmVote) && (
               <ProposerAddress>
                 Proposer:{" "}
                 <a
@@ -267,7 +266,7 @@ const RequestForm: FC = () => {
                 </a>
               </ProposerAddress>
             )}
-            {flags.CanDispute && disputer && (
+            {(flags.CanDispute || flags.InDvmVote) && disputer && (
               <ProposerAddress>
                 Disputer:{" "}
                 <a

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -260,7 +260,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}/tx/${proposer}`}
+                  href={`${explorerUrl}/address/${proposer}`}
                 >
                   {proposer}
                 </a>
@@ -272,7 +272,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}/tx/${disputer}`}
+                  href={`${explorerUrl}/address/${disputer}`}
                 >
                   {disputer}
                 </a>

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -260,7 +260,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}address/${proposer}`}
+                  href={`${explorerUrl}/address/${proposer}`}
                 >
                   {proposer}
                 </a>
@@ -272,7 +272,7 @@ const RequestForm: FC = () => {
                 <a
                   target="_blank"
                   rel="noreferrer"
-                  href={`${explorerUrl}address/${disputer}`}
+                  href={`${explorerUrl}/address/${disputer}`}
                 >
                   {disputer}
                 </a>

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -25,7 +25,7 @@ import useReader from "hooks/useOracleReader";
 import { ethers } from "ethers";
 import { prettyFormatNumber } from "helpers/format";
 import BouncingDotsLoader from "components/bouncing-dots-loader";
-
+import { NULL_ADDRESS } from "constants/blockchain";
 const RequestForm: FC = () => {
   const [currentTime, setCurrentTime] = useState(0);
   const [value, setValue] = useState("");
@@ -266,18 +266,20 @@ const RequestForm: FC = () => {
                 </a>
               </ProposerAddress>
             )}
-            {(flags.CanDispute || flags.InDvmVote) && disputer && (
-              <ProposerAddress>
-                Disputer:{" "}
-                <a
-                  target="_blank"
-                  rel="noreferrer"
-                  href={`${explorerUrl}/address/${disputer}`}
-                >
-                  {disputer}
-                </a>
-              </ProposerAddress>
-            )}
+            {(flags.CanDispute || flags.InDvmVote) &&
+              disputer &&
+              disputer !== NULL_ADDRESS && (
+                <ProposerAddress>
+                  Disputer:{" "}
+                  <a
+                    target="_blank"
+                    rel="noreferrer"
+                    href={`${explorerUrl}/address/${disputer}`}
+                  >
+                    {disputer}
+                  </a>
+                </ProposerAddress>
+              )}
           </RequestFormInputWrapper>
         </RequestFormHeaderAndFormWrapper>
         <RequestFormParametersWrapper>

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -99,7 +99,7 @@ const RequestForm: FC = () => {
         onClick: () => client.switchOrAddChain(),
         disabled: false,
       };
-    if (flags.ProposalInProgress)
+    if (flags.ProposalTxInProgress)
       return {
         label: "Proposing...",
         onClick: undefined,
@@ -143,7 +143,7 @@ const RequestForm: FC = () => {
         onClick: () => client.switchOrAddChain(),
         disabled: false,
       };
-    if (flags.DisputeInProgress)
+    if (flags.DisputeTxInProgress)
       return {
         label: "Disputing...",
         onClick: undefined,
@@ -165,23 +165,23 @@ const RequestForm: FC = () => {
   const getButton = (value: string) => {
     if (flags.MissingRequest) return <div>Loading Request State...</div>;
     if (
-      flags.ApprovalInProgress ||
-      flags.ProposalInProgress ||
-      flags.DisputeInProgress
+      flags.ApprovalTxInProgress ||
+      flags.ProposalTxInProgress ||
+      flags.DisputeTxInProgress
     )
       return (
         <RequestFormButton>
           <BouncingDotsLoader />
         </RequestFormButton>
       );
-    if (flags.InProposeState) {
+    if (flags.CanPropose) {
       const buttonProps = getProposeButtonProps(value);
       return (
         <RequestFormButton {...buttonProps}>
           {buttonProps.label}
         </RequestFormButton>
       );
-    } else if (flags.InDisputeState) {
+    } else if (flags.CanDispute) {
       const buttonProps = getDisputeButtonProps();
       return (
         <RequestFormButton {...buttonProps}>
@@ -196,7 +196,7 @@ const RequestForm: FC = () => {
   };
 
   useEffect(() => {
-    if (expirationTime && flags.InDisputeState) {
+    if (expirationTime && flags.CanDispute) {
       setCurrentTime(calculateTimeRemaining(Date.now(), expirationTime * 1000));
       const timer = setInterval(
         () =>
@@ -207,15 +207,15 @@ const RequestForm: FC = () => {
       );
       return () => clearInterval(timer);
     }
-  }, [expirationTime, liveness, flags.InDisputeState]);
+  }, [expirationTime, liveness, flags.CanDispute]);
 
   return (
     <RequestFormWrapper>
       <RequestFormRow>
         <RequestFormHeaderAndFormWrapper>
           <FormHeader>
-            {flags.InProposeState && "Proposal"}
-            {flags.InDisputeState && "Dispute Period"}
+            {flags.CanPropose && "Proposal"}
+            {flags.CanDispute && "Dispute Period"}
             {requestState === oracle.types.state.RequestState.Disputed && (
               <>
                 <div>Proposal</div>
@@ -235,14 +235,14 @@ const RequestForm: FC = () => {
           </FormHeader>
           <RequestFormInputWrapper>
             <RequestInputButtonBlock>
-              {flags.InProposeState && (
+              {flags.CanPropose && (
                 <RequestFormInput
                   label="Propose: "
                   value={value}
                   onChange={inputOnChange}
                 />
               )}
-              {(flags.InDisputeState ||
+              {(flags.CanDispute ||
                 requestState === oracle.types.state.RequestState.Disputed) &&
                 proposedPrice && (
                   <RequestFormInput
@@ -255,7 +255,7 @@ const RequestForm: FC = () => {
               {getButton(value)}
             </RequestInputButtonBlock>
             {inputError && <InputError>{inputError}</InputError>}
-            {flags.InDisputeState && (
+            {flags.CanDispute && (
               <ProposerAddress>
                 Proposer:{" "}
                 <a
@@ -267,7 +267,7 @@ const RequestForm: FC = () => {
                 </a>
               </ProposerAddress>
             )}
-            {flags.DisputeInProgress && (
+            {flags.CanDispute && disputer && (
               <ProposerAddress>
                 Disputer:{" "}
                 <a
@@ -300,7 +300,7 @@ const RequestForm: FC = () => {
           <ParametersValuesWrapper>
             <ParametersValueHeader>Liveness period: </ParametersValueHeader>
             <ParametersValue>
-              {flags.InDisputeState && (
+              {flags.CanDispute && (
                 <>
                   Time remaining:{" "}
                   {Duration.fromMillis(currentTime).toFormat(

--- a/src/constants/blockchain.ts
+++ b/src/constants/blockchain.ts
@@ -43,7 +43,7 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
     chainId: ChainId.POLYGON,
     logoURI: polygonLogo,
     rpcUrl: "https://polygon-rpc.com/",
-    explorerUrl: "https://polygonscan.com/",
+    explorerUrl: "https://polygonscan.com",
     constructExplorerLink: (txHash: string) =>
       `https://polygonscan.com/tx/${txHash}`,
     nativeCurrency: {

--- a/src/constants/blockchain.ts
+++ b/src/constants/blockchain.ts
@@ -89,3 +89,5 @@ export enum RequestState {
   Resolved, // 5 Disputed and DVM price is available.
   Settled, // 6 Final price has been set in the contract (can get here from Expired or Resolved).
 }
+
+export const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,10 +3246,10 @@
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.2.1.tgz#29ebba6b2ecba7f0d2dc9b484bc34f0abbdefdaa"
   integrity sha512-7wPkH/m8tD8UMLYUjSXN5gSp/5NsuPRF1icmwXNTWlhp/Mg4qmJHeANjsWP9JCDxlgdSDixA4hJ5qhVOPXFniA==
 
-"@uma/sdk@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.20.0.tgz#ba5ed86a67d7546ed78c84bd681fdfe4c7b7fec0"
-  integrity sha512-BkBb8TdWQwahSLaj34+1IIZKWxnwCE9k4/xyAoMOqycw8AkgzG4sR8XYkwVdrtTXoe8vrD0LZ2JQyKhMiMZkkQ==
+"@uma/sdk@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.21.0.tgz#632b8aaf20be21b698306f020724fa2517765285"
+  integrity sha512-L62KTN20ria+Aw2H0SPcaAqBPIWTknOkGqgtI9xCf31M40db4uun9mKvpJkeL5RkaVM2Mr85Vo+3cRD9KesERg==
   dependencies:
     "@google-cloud/datastore" "^6.6.0"
     "@types/lodash-es" "^4.17.5"


### PR DESCRIPTION
1. Bump SDK version to 0.21.0
2. Swap to new flags:
InProposeState becomes CanPropose
InDisputeState becomes CanDispute
ProposalInProgress becomes ProposalTxInProgress
ApprovalInProgress becomes ApprovalTxInProgress
DisputeInProgress becomes DisputeTxInProgress

CanSettle - request is in a state the user can call settle
InDvmVote - request is wiating for dvm vote
RequestSettled - request has been settled, ie no more changes
3. Very basic Settle state (functionality not ready)


Fixed issue with links:
https://app.shortcut.com/uma-project/story/4201/instead-of-showing-the-address-of-the-proposer-and-disputer-lets-update-disputer-to-dispute-and-proposer-to-proposal-and