### PR TITLE
fix: Change parameter language when disputing

### DIFF
--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -285,21 +285,44 @@ const RequestForm: FC = () => {
         <RequestFormParametersWrapper>
           <ParametersHeader>Parameters</ParametersHeader>
           <ParametersValuesWrapper>
-            <ParametersValueHeader>Proposal bond:</ParametersValueHeader>
+            <ParametersValueHeader>
+              {flags.CanPropose
+                ? "Proposal bond"
+                : flags.CanDispute || flags.InDvmVote || flags.CanSettle
+                ? "Disputer bond"
+                : ""}
+            </ParametersValueHeader>
             <ParametersValue>
               <BondLogo src={logo} alt="bond_img" /> {collateralSymbol}{" "}
               {totalBond ? prettyFormatNumber(Number(totalBond)) : ""}
             </ParametersValue>
           </ParametersValuesWrapper>
           <ParametersValuesWrapper>
-            <ParametersValueHeader>Proposal reward:</ParametersValueHeader>
+            <ParametersValueHeader>
+              {flags.CanPropose
+                ? "Proposal reward"
+                : flags.CanDispute || flags.InDvmVote || flags.CanSettle
+                ? "Disputer reward"
+                : ""}
+            </ParametersValueHeader>
             <ParametersValue>
               <BondLogo src={logo} alt="bond_img" /> {collateralSymbol}{" "}
               {reward ? prettyFormatNumber(Number(reward)) : ""}
             </ParametersValue>
           </ParametersValuesWrapper>
+          {flags.CanDispute || flags.InDvmVote || flags.CanSettle ? (
+            <ParametersValuesWrapper>
+              <ParametersValueHeader>Sponsor Reward</ParametersValueHeader>
+              <ParametersValue>
+                <BondLogo src={logo} alt="bond_img" /> {collateralSymbol}{" "}
+                {reward ? prettyFormatNumber(Number(reward)) : ""}
+              </ParametersValue>
+            </ParametersValuesWrapper>
+          ) : null}
           <ParametersValuesWrapper>
-            <ParametersValueHeader>Liveness period: </ParametersValueHeader>
+            {flags.CanDispute && (
+              <ParametersValueHeader>Liveness period: </ParametersValueHeader>
+            )}
             <ParametersValue>
               {flags.CanDispute && (
                 <>

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -217,7 +217,7 @@ const RequestForm: FC = () => {
             {flags.CanDispute && "Dispute Period"}
             {flags.InDvmVote && (
               <>
-                <div>Proposal</div>
+                <div>Dispute Period</div>
                 <div>
                   Disputed and sent to UMA's Data Verification Mechanism (DVM)
                   for resolution.{" "}

--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -319,21 +319,19 @@ const RequestForm: FC = () => {
               </ParametersValue>
             </ParametersValuesWrapper>
           ) : null}
-          <ParametersValuesWrapper>
-            {flags.CanDispute && (
+          {flags.CanDispute && (
+            <ParametersValuesWrapper>
               <ParametersValueHeader>Liveness period: </ParametersValueHeader>
-            )}
-            <ParametersValue>
-              {flags.CanDispute && (
+              <ParametersValue>
                 <>
                   Time remaining:{" "}
                   {Duration.fromMillis(currentTime).toFormat(
                     "hh 'h' mm' min' s' sec' left"
                   )}
                 </>
-              )}
-            </ParametersValue>
-          </ParametersValuesWrapper>
+              </ParametersValue>
+            </ParametersValuesWrapper>
+          )}
         </RequestFormParametersWrapper>
       </RequestFormRow>
     </RequestFormWrapper>


### PR DESCRIPTION
Adjusted parameters text when disputing.
<img width="530" alt="Screen Shot 2022-01-31 at 3 41 03 PM" src="https://user-images.githubusercontent.com/12792146/151891164-2da59447-b4d9-4c64-a9e1-3dd0afb434d4.png">



Signed-off-by: Tulun <jaykiraly@gmail.com>