### PR TITLE
feat: add parsed identifier to reader, request and settle page

### DIFF
--- a/src/components/request/Request.tsx
+++ b/src/components/request/Request.tsx
@@ -28,7 +28,8 @@ const Request = () => {
   const [searchParams] = useSearchParams();
   const { rows, headerCells } = useRequestTableData(searchParams);
 
-  const { proposer, disputer, proposedPrice } = useReader(state);
+  const { proposer, disputer, proposedPrice, parsedIdentifier } =
+    useReader(state);
 
   useEffect(() => {
     const requester = searchParams.get("requester")?.trim();
@@ -63,6 +64,7 @@ const Request = () => {
               proposer={proposer}
               disputer={disputer}
               proposedPrice={proposedPrice}
+              parsedIdentifier={parsedIdentifier}
               chainId={
                 searchParams.get("chainId") &&
                 Number(searchParams.get("chainId"))

--- a/src/components/request/RequestHero.tsx
+++ b/src/components/request/RequestHero.tsx
@@ -31,13 +31,15 @@ const RequestHero: FC<Props> = ({ chainId }) => {
     chainName = CHAINS[chainId].name;
   }
   const { oracle, state } = useClient();
-  const { requestState } = useReader(state);
+  const { requestState, parsedIdentifier } = useReader(state);
 
   return (
     <HeroSection>
       <HeroContentWrapper>
         <HeroHeaderRow>
-          <HeaderTitle>Optimistic Oracle Request</HeaderTitle>
+          <HeaderTitle>
+            {parsedIdentifier || "Optimistic Oracle Request"}
+          </HeaderTitle>
           <HeaderButtonWrapper>
             <HeroButton>
               <HeroButtonFlex>

--- a/src/components/request/SettledTable.tsx
+++ b/src/components/request/SettledTable.tsx
@@ -17,18 +17,21 @@ interface Props {
   disputer: string | undefined;
   proposedPrice: oracle.types.ethers.BigNumber | undefined;
   chainId: number | "" | null;
+  parsedIdentifier: string | undefined;
 }
 const SettledTable: FC<Props> = ({
   proposer,
   disputer,
   proposedPrice,
   chainId,
+  parsedIdentifier,
 }) => {
   const { rows, headerCells } = useSettledTableData(
     proposer,
     disputer,
     proposedPrice,
-    chainId
+    chainId,
+    parsedIdentifier
   );
 
   return (

--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -3,6 +3,7 @@ import { ICell, IRow } from "../table/Table";
 import { DateTime } from "luxon";
 import { ethers } from "ethers";
 import { CHAINS, ChainId } from "constants/blockchain";
+import { parseIdentifier } from "../../helpers/format";
 
 const hc: ICell[] = [
   {
@@ -63,16 +64,11 @@ function useRequestTableData(searchParams: URLSearchParams) {
 
     let nextIdentifier = searchParams.get("identifier");
     let convertedIdentifier = "";
-    if (nextIdentifier) {
-      try {
-        // replace non ascii chars
-        convertedIdentifier = ethers.utils
-          .toUtf8String(nextIdentifier)
-          .replace(/[^\x20-\x7E]+/g, "");
-      } catch (err) {
-        convertedIdentifier = "Not convertible to UTF-8 string.";
-        console.log("not convertible to UTF8");
-      }
+    try {
+      convertedIdentifier = parseIdentifier(nextIdentifier);
+    } catch (err) {
+      console.error(err);
+      convertedIdentifier = "Not convertible to UTF-8 string.";
     }
     nextRows.push({
       cells: [

--- a/src/components/request/useSettledTableData.tsx
+++ b/src/components/request/useSettledTableData.tsx
@@ -10,13 +10,27 @@ function useSettledTableData(
   proposer: string | undefined,
   disputer: string | undefined,
   proposedPrice: oracle.types.ethers.BigNumber | undefined,
-  chainId: number | "" | null
+  chainId: number | "" | null,
+  parsedIdentifier: string | undefined
 ) {
   const [rows, setRows] = useState<IRow[]>([]);
   const [headerCells] = useState<ICell[]>(hc);
   const cid: ChainId = chainId ? chainId : 1;
   useEffect(() => {
     let nextRows = [
+      {
+        cells: [
+          {
+            size: "md",
+            value: "Query",
+            cellClassName: "first-cell",
+          },
+          {
+            size: "lg",
+            value: parsedIdentifier || "",
+          },
+        ],
+      },
       {
         cells: [
           {
@@ -90,7 +104,7 @@ function useSettledTableData(
       });
     }
     setRows(nextRows);
-  }, [proposer, disputer, proposedPrice, cid]);
+  }, [proposer, disputer, proposedPrice, cid, parsedIdentifier]);
 
   return { rows, headerCells };
 }

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,3 +1,5 @@
+import { ethers } from "ethers";
+
 export const prettyFormatNumber = Intl.NumberFormat("en-US").format;
 
 export class Explorer {
@@ -17,4 +19,11 @@ export function shortenString(str: string, length = 10) {
   const first = str.slice(0, offset);
   const last = str.slice(-offset);
   return [first, last].join("...");
+}
+
+export function parseIdentifier(identifier: string | null | undefined) {
+  // replace non ascii chars
+  return ethers.utils
+    .toUtf8String(identifier || "")
+    .replace(/[^\x20-\x7E]+/g, "");
 }

--- a/src/hooks/useOracleReader.ts
+++ b/src/hooks/useOracleReader.ts
@@ -4,7 +4,7 @@ import umaLogo from "assets/uma-logo.png";
 import { CHAINS, ChainId } from "constants/blockchain";
 
 import { oracle } from "../helpers/oracleClient";
-import { Explorer } from "../helpers/format";
+import { Explorer, parseIdentifier } from "../helpers/format";
 
 const { formatUnits } = ethers.utils;
 const { ignoreExistenceError } = oracle.errors;
@@ -58,6 +58,14 @@ export default function useOracleReader(state: oracle.types.state.State) {
   const exploreProposerAddress = proposer && explorer.address(proposer);
   const exploreDisputerAddress = disputer && explorer.address(disputer);
 
+  let parsedIdentifier = "";
+  try {
+    parsedIdentifier = parseIdentifier(request?.identifier);
+  } catch (err) {
+    // ignore error
+    console.error(err);
+  }
+
   return {
     totalBond,
     reward,
@@ -80,5 +88,6 @@ export default function useOracleReader(state: oracle.types.state.State) {
     exploreSettleTx,
     exploreProposerAddress,
     exploreDisputerAddress,
+    parsedIdentifier,
   };
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Adds a parsed identifier to request and settle pages. adds a utility to parse identifier. 

After:
![image](https://user-images.githubusercontent.com/4429761/153916176-914153ca-6ba2-4dae-a2da-9e21933a2000.png)
![image](https://user-images.githubusercontent.com/4429761/153916294-696ed360-282c-4595-8f51-fcad8091f2ba.png)
