### PR TITLE
fix: disable polling in ethers provider

### DIFF
--- a/src/helpers/onboard.ts
+++ b/src/helpers/onboard.ts
@@ -19,6 +19,8 @@ export const onboard = Onboard({
         const provider = new ethers.providers.Web3Provider(
           wallet.provider
         ) as oracle.types.ethers.Web3Provider;
+        // disable polling, this tends to cause a lot of requests to underlying provider if not disabled
+        provider.polling = false
         client.setUser({ signer: provider.getSigner(), provider });
       }
     },

--- a/src/helpers/onboard.ts
+++ b/src/helpers/onboard.ts
@@ -4,25 +4,41 @@ import { client, oracle } from "./oracleClient";
 import onboardBaseConfig from "./onboardBaseConfig";
 import { Wallet } from "bnc-onboard/dist/src/interfaces";
 
+let currentWallet: Wallet | undefined;
+const debug = Boolean(process.env.REACT_APP_DEBUG);
+
 export const onboard = Onboard({
   ...onboardBaseConfig(),
   subscriptions: {
     address: (address: string) => {
-      if (address)
+      debug && console.log("onboard address change", address);
+      if (address) {
         client.setUser({ address: ethers.utils.getAddress(address) });
+      } else {
+        // address is undefined when metamask wallet is logged out, so run the disconnect routine
+        disconnect();
+      }
     },
     network: (networkId: number) => {
-      if (networkId) client.setUser({ chainId: networkId });
+      debug && console.log("onboard network change", networkId);
+      if (!networkId) return;
+      const params: Parameters<typeof client.setUser>["0"] = {
+        chainId: networkId,
+      };
+      if (currentWallet && currentWallet.provider) {
+        params.provider = new ethers.providers.Web3Provider(
+          currentWallet.provider
+        ) as oracle.types.ethers.Web3Provider;
+        params.provider.polling = false;
+        params.signer = params.provider.getSigner();
+      }
+      client.setUser(params);
     },
     wallet: async (wallet: Wallet) => {
-      if (wallet.provider) {
-        const provider = new ethers.providers.Web3Provider(
-          wallet.provider
-        ) as oracle.types.ethers.Web3Provider;
-        // disable polling, this tends to cause a lot of requests to underlying provider if not disabled
-        provider.polling = false
-        client.setUser({ signer: provider.getSigner(), provider });
-      }
+      debug && console.log("onboard wallet change", wallet);
+      // turns out this callback is not fired on network changes, meaning provider is out of date in client.
+      // so we use network change event to submit the provider and signer to the oracle client.
+      currentWallet = wallet;
     },
   },
 });


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This is related to this issue: https://github.com/UMAprotocol/protocol/pull/3833

Disabling this seems to silence a lot of unecessary calls to provider, and prevents spam overwhelming a local testing node. 