### PR TITLE
feat(oo-ui): add tx hash to data

### DIFF
--- a/src/components/request/Request.tsx
+++ b/src/components/request/Request.tsx
@@ -17,11 +17,11 @@ import useRequestParams, {
   isByTransactionRequest,
 } from "hooks/useRequestParams";
 import useIsByTransactionParams from "hooks/useIsByTransactionParams";
+import { ChainId } from "constants/blockchain";
 
 const Request = () => {
   const { client, state, flags } = useClient();
   const [searchParams] = useSearchParams();
-  const { rows, headerCells } = useRequestTableData(searchParams);
 
   const {
     chainId,
@@ -30,8 +30,22 @@ const Request = () => {
     exploreProposeTx,
     exploreDisputeTx,
     proposedPrice,
+    requester,
+    ancillaryData,
+    identifier,
+    timestamp,
     parsedIdentifier,
+    requestTx,
   } = useReader(state);
+
+  const { rows, headerCells } = useRequestTableData({
+    chainId: (Number(searchParams.get("chainId")) as ChainId) || chainId,
+    requester: searchParams.get("requester") ?? requester,
+    identifier: searchParams.get("identifier") ?? identifier,
+    ancillaryData: searchParams.get("ancillaryData") ?? ancillaryData,
+    timestamp: Number(searchParams.get("timestamp")) || timestamp,
+    requestTxHash: requestTx,
+  });
 
   const isByTransactionParams = useIsByTransactionParams();
   const { request, error } = useRequestParams(isByTransactionParams);

--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -24,20 +24,62 @@ const hc: ICell[] = [
   },
 ];
 
-function useRequestTableData(searchParams: URLSearchParams) {
+type UseRequestTableParams = {
+  chainId?: ChainId;
+  requester?: string;
+  identifier?: string;
+  timestamp?: number;
+  ancillaryData?: string;
+  requestTxHash?: string;
+};
+function useRequestTableData({
+  chainId = 1,
+  requester,
+  identifier,
+  timestamp,
+  ancillaryData,
+  requestTxHash,
+}: UseRequestTableParams) {
   const [rows, setRows] = useState<IRow[]>([]);
   const [headerCells] = useState<ICell[]>(hc);
 
   useEffect(() => {
     const nextRows = [] as IRow[];
 
-    const nextRequester = searchParams.get("requester");
-    const chainId: ChainId = Number(searchParams.get("chainId")) || 1;
     nextRows.push({
       cells: [
         {
           size: "xs",
           value: "0",
+        },
+        {
+          size: "sm",
+          value: "Request",
+        },
+        {
+          size: "sm",
+          value: "bytes",
+        },
+        {
+          size: "lg",
+          value: (
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`${CHAINS[chainId].explorerUrl}/tx/${requestTxHash}`}
+            >
+              {requestTxHash}
+            </a>
+          ),
+        },
+      ],
+    });
+
+    nextRows.push({
+      cells: [
+        {
+          size: "xs",
+          value: "1",
         },
         {
           size: "sm",
@@ -53,19 +95,18 @@ function useRequestTableData(searchParams: URLSearchParams) {
             <a
               target="_blank"
               rel="noreferrer"
-              href={`${CHAINS[chainId].explorerUrl}/address/${nextRequester}`}
+              href={`${CHAINS[chainId].explorerUrl}/address/${requester}`}
             >
-              {nextRequester}
+              {requester}
             </a>
           ),
         },
       ],
     });
 
-    let nextIdentifier = searchParams.get("identifier");
     let convertedIdentifier = "";
     try {
-      convertedIdentifier = parseIdentifier(nextIdentifier);
+      convertedIdentifier = parseIdentifier(identifier);
     } catch (err) {
       console.error(err);
       convertedIdentifier = "Not convertible to UTF-8 string.";
@@ -74,7 +115,7 @@ function useRequestTableData(searchParams: URLSearchParams) {
       cells: [
         {
           size: "xs",
-          value: "1",
+          value: "2",
         },
         {
           size: "sm",
@@ -90,13 +131,12 @@ function useRequestTableData(searchParams: URLSearchParams) {
         },
       ],
     });
-    const nextTimestamp = searchParams.get("timestamp");
 
     nextRows.push({
       cells: [
         {
           size: "xs",
-          value: "2",
+          value: "3",
         },
         {
           size: "sm",
@@ -108,20 +148,19 @@ function useRequestTableData(searchParams: URLSearchParams) {
         },
         {
           size: "lg",
-          value: nextTimestamp
-            ? `${DateTime.fromSeconds(Number(nextTimestamp)).toFormat(
+          value: timestamp
+            ? `${DateTime.fromSeconds(timestamp).toFormat(
                 "LLL. dd yyyy hh:mm:ss"
-              )} (${nextTimestamp})`
+              )} (${timestamp})`
             : "",
         },
       ],
     });
 
-    let nextAncillaryData = searchParams.get("ancillaryData");
     let convertedAncillaryData = "";
-    if (nextAncillaryData && nextAncillaryData !== "0x") {
+    if (ancillaryData && ancillaryData !== "0x") {
       try {
-        convertedAncillaryData = ethers.utils.toUtf8String(nextAncillaryData);
+        convertedAncillaryData = ethers.utils.toUtf8String(ancillaryData);
       } catch (err) {
         convertedAncillaryData = "Not convertible to UTF-8 string.";
         console.log("not convertible to UTF8");
@@ -134,7 +173,7 @@ function useRequestTableData(searchParams: URLSearchParams) {
       cells: [
         {
           size: "xs",
-          value: "3",
+          value: "4",
         },
         {
           size: "sm",
@@ -155,7 +194,7 @@ function useRequestTableData(searchParams: URLSearchParams) {
       cells: [
         {
           size: "xs",
-          value: "4",
+          value: "5",
         },
         {
           size: "sm",
@@ -167,12 +206,12 @@ function useRequestTableData(searchParams: URLSearchParams) {
         },
         {
           size: "lg",
-          value: nextAncillaryData ?? "",
+          value: ancillaryData ?? "",
         },
       ],
     });
     setRows(nextRows);
-  }, [searchParams]);
+  }, [chainId, requester, identifier, timestamp, ancillaryData, requestTxHash]);
 
   return { rows, headerCells };
 }

--- a/src/hooks/useOracleReader.ts
+++ b/src/hooks/useOracleReader.ts
@@ -58,6 +58,11 @@ export default function useOracleReader(state: oracle.types.state.State) {
   const exploreProposerAddress = proposer && explorer.address(proposer);
   const exploreDisputerAddress = disputer && explorer.address(disputer);
 
+  const requester = request?.requester;
+  const identifier = request?.identifier;
+  const ancillaryData = request?.ancillaryData;
+  const timestamp = request?.timestamp;
+
   let parsedIdentifier = "";
   try {
     parsedIdentifier = parseIdentifier(request?.identifier);
@@ -79,6 +84,10 @@ export default function useOracleReader(state: oracle.types.state.State) {
     requestState,
     proposedPrice,
     disputer,
+    requester,
+    identifier,
+    ancillaryData,
+    timestamp,
     proposer,
     requestTx,
     proposeTx,


### PR DESCRIPTION
Adds the tx hash as in: https://app.shortcut.com/uma-project/story/4199/within-input-data-add-a-row-before-requestor-with-the-tx-hash-of-the-request-name-request-type-address-data-the-tx-hash-of


Signed-off-by: Gamaranto <francesco@umaproject.org>