### PR TITLE
feat: change title of yes_no_query to part of question

### DIFF
--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -4,7 +4,7 @@ import { oracle } from "@uma/sdk";
 import { StyledLink, AlertLogo } from "./RequestsTable.styled";
 import { parseIdentifier } from "helpers/format";
 import { ethers } from "ethers";
-import { formatYesNoQueryString } from "helpers/format";
+import { formatRequestTitle } from "helpers/format";
 import alertIcon from "assets/alert-icon.svg";
 
 const headerCells: ICell[] = [
@@ -35,26 +35,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
 
   if (requests.length) {
     requests.forEach((req) => {
-      let identifier = "";
-      try {
-        identifier = parseIdentifier(req.identifier);
-        if (identifier === "YES_OR_NO_QUERY") {
-          try {
-            identifier = formatYesNoQueryString(
-              ethers.utils.toUtf8String(req.ancillaryData)
-            );
-          } catch (err: any) {
-            console.error(
-              "error with formatYesNoQueryString call",
-              err.message
-            );
-          }
-        }
-      } catch (err: any) {
-        identifier = req.identifier;
-        console.log("Error in parsing identifier", err.message);
-      }
-
+      let identifier = formatRequestTitle(req);
       const timestamp = DateTime.fromSeconds(Number(req.timestamp)).toFormat(
         "LLL. dd yyyy hh:mm:ss a"
       );

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -35,7 +35,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
 
   if (requests.length) {
     requests.forEach((req) => {
-      let identifier = formatRequestTitle(req);
+      const identifier = formatRequestTitle(req);
       const timestamp = DateTime.fromSeconds(Number(req.timestamp)).toFormat(
         "LLL. dd yyyy hh:mm:ss a"
       );

--- a/src/components/request/RequestHero.tsx
+++ b/src/components/request/RequestHero.tsx
@@ -18,6 +18,7 @@ import { CHAINS, ChainId } from "constants/blockchain";
 import useClient from "hooks/useOracleClient";
 import useReader from "hooks/useOracleReader";
 import alertIcon from "assets/alert-icon.svg";
+import { formatRequestTitle } from "helpers/format";
 
 interface Props {
   chainId: ChainId;
@@ -32,15 +33,20 @@ const RequestHero: FC<Props> = ({ chainId }) => {
     chainName = CHAINS[chainId].name;
   }
   const { oracle, state } = useClient();
-  const { requestState, parsedIdentifier, requestTx, exploreRequestTx } =
-    useReader(state);
+  const {
+    requestState,
+    requestTx,
+    exploreRequestTx,
+    identifier,
+    ancillaryData,
+  } = useReader(state);
 
   return (
     <HeroSection>
       <HeroContentWrapper>
         <HeroHeaderRow>
           <HeaderTitle>
-            {parsedIdentifier || "Optimistic Oracle Request"}
+            {formatRequestTitle({ identifier, ancillaryData })}
             {requestTx && (
               <RequestTxText>
                 Request:{" "}

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -28,10 +28,20 @@ export function parseIdentifier(identifier: string | null | undefined) {
     .replace(/[^\x20-\x7E]+/g, "");
 }
 
+export function parseAncillaryData(ancillaryData: string) {
+  return ethers.utils.toUtf8String(ancillaryData);
+}
+
+export function validateYesNoQueryString(parsedAncillaryData: string) {
+  return (
+    parsedAncillaryData.includes("title: ") &&
+    parsedAncillaryData.includes("description: ")
+  );
+}
+
 // String has a particular format that includes break points like q: title: description:
 // Split the string based on these common parts of query strings.
-
-export function formatYesNoQueryString(str: string) {
+export function formatYesNoQueryString(str: string, maxLength = 55) {
   // Split the string before title:
   const splitOne = str.split("title: ")[1];
 
@@ -42,9 +52,45 @@ export function formatYesNoQueryString(str: string) {
   const formatted = title.substring(0, title.length - 2);
 
   // Return only the first 55 characters
-  if (formatted.length > 55) {
-    return `${formatted.substring(0, 56)}...`;
+  if (formatted.length > maxLength) {
+    return `${formatted.substring(0, maxLength + 1)}...`;
   } else {
     return formatted;
   }
+}
+
+type FormatRequestTitleParams = {
+  identifier?: string;
+  ancillaryData?: string;
+  maxTitleLength?: number;
+  defaultTitle?: string;
+};
+
+export function formatRequestTitle(params: FormatRequestTitleParams) {
+  const {
+    identifier,
+    ancillaryData,
+    maxTitleLength = 55,
+    defaultTitle = "Optimistic Oracle Request",
+  } = params;
+  let title = defaultTitle;
+  try {
+    const parsedIdentifier = identifier
+      ? parseIdentifier(identifier)
+      : undefined;
+
+    if (parsedIdentifier) title = parsedIdentifier;
+
+    if (parsedIdentifier === "YES_OR_NO_QUERY") {
+      if (!ancillaryData) return parsedIdentifier;
+      const parsedAncillaryData = parseAncillaryData(ancillaryData);
+      if (!validateYesNoQueryString(parsedAncillaryData))
+        return parsedIdentifier;
+      return formatYesNoQueryString(parsedAncillaryData, maxTitleLength);
+    }
+    // add future parsers here
+  } catch (err) {
+    console.error("Error Formatting Request Title", err, params);
+  }
+  return title;
 }

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -2,6 +2,10 @@ import { ethers } from "ethers";
 
 export const prettyFormatNumber = Intl.NumberFormat("en-US").format;
 
+// maximum length for a yes/no query ancillary question title
+export const MAX_TITLE_LENGTH = 55;
+export const DEFAULT_REQUEST_TITLE = "Optimistic Oracle Request";
+
 export class Explorer {
   constructor(private base: string) {}
   tx = (hash: string): string => {
@@ -41,7 +45,10 @@ export function validateYesNoQueryString(parsedAncillaryData: string) {
 
 // String has a particular format that includes break points like q: title: description:
 // Split the string based on these common parts of query strings.
-export function formatYesNoQueryString(str: string, maxLength = 55) {
+export function formatYesNoQueryString(
+  str: string,
+  maxLength = MAX_TITLE_LENGTH
+) {
   // Split the string before title:
   const splitOne = str.split("title: ")[1];
 
@@ -59,19 +66,19 @@ export function formatYesNoQueryString(str: string, maxLength = 55) {
   }
 }
 
-type FormatRequestTitleParams = {
+interface FormatRequestTitleParams {
   identifier?: string;
   ancillaryData?: string;
   maxTitleLength?: number;
   defaultTitle?: string;
-};
+}
 
 export function formatRequestTitle(params: FormatRequestTitleParams) {
   const {
     identifier,
     ancillaryData,
-    maxTitleLength = 55,
-    defaultTitle = "Optimistic Oracle Request",
+    maxTitleLength = MAX_TITLE_LENGTH,
+    defaultTitle = DEFAULT_REQUEST_TITLE,
   } = params;
   let title = defaultTitle;
   try {

--- a/src/hooks/useIsByTransactionParams.ts
+++ b/src/hooks/useIsByTransactionParams.ts
@@ -1,11 +1,13 @@
-import { useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
-
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 
 /**
- * this function DOES NOT validate that the URL is valid, it assumes it to be valid, and then checks if it matches a legacy URL 
+ * this function DOES NOT validate that the URL is valid, it assumes it to be valid, and then checks if it matches a legacy URL
  * */
 export default function useIsByTransactionParams(): boolean {
-	const [searchParams] = useSearchParams();
-	return useMemo(() => { const value = searchParams.get("transactionHash"); return value !== null }, [searchParams]);
+  const [searchParams] = useSearchParams();
+  return useMemo(() => {
+    const value = searchParams.get("transactionHash");
+    return value !== null;
+  }, [searchParams]);
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Adds a utility function to parse the type of title required based on identifier. Uses this in 2 places, one in the main list of requests, and the other in the title of yes/no request details page. 

![image](https://user-images.githubusercontent.com/4429761/156780774-f2d6c9f2-40e1-4f60-a4b4-b211a005737b.png)
