### PR TITLE
fix: timestamp now shown in utc time

### DIFF
--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -1,10 +1,9 @@
 import { ICell, IRow } from "../table/Table";
-import { DateTime } from "luxon";
 import { oracle } from "@uma/sdk";
 import { StyledLink, AlertLogo } from "./RequestsTable.styled";
 import { parseIdentifier } from "helpers/format";
 import { ethers } from "ethers";
-import { formatRequestTitle } from "helpers/format";
+import { formatRequestTitle, formatTime } from "helpers/format";
 import alertIcon from "assets/alert-icon.svg";
 
 const headerCells: ICell[] = [
@@ -36,9 +35,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
   if (requests.length) {
     requests.forEach((req) => {
       const identifier = formatRequestTitle(req);
-      const timestamp = DateTime.fromSeconds(Number(req.timestamp)).toFormat(
-        "LLL. dd yyyy hh:mm:ss a"
-      );
+      const timestamp = formatTime(req.timestamp);
 
       let requestState: any = "Invalid";
       if (req.state === oracle.types.state.RequestState.Requested)

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -3,7 +3,7 @@ import { oracle } from "@uma/sdk";
 import { StyledLink, AlertLogo } from "./RequestsTable.styled";
 import { parseIdentifier } from "helpers/format";
 import { ethers } from "ethers";
-import { formatRequestTitle, formatTime } from "helpers/format";
+import { formatRequestTitle, formatTime, formatDate } from "helpers/format";
 import alertIcon from "assets/alert-icon.svg";
 
 const headerCells: ICell[] = [
@@ -35,7 +35,13 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
   if (requests.length) {
     requests.forEach((req) => {
       const identifier = formatRequestTitle(req);
-      const timestamp = formatTime(req.timestamp);
+      const timestamp = req.timestamp ? (
+        <div>
+          {formatDate(req.timestamp)}
+          <br />
+          {formatTime(req.timestamp)}
+        </div>
+      ) : undefined;
 
       let requestState: any = "Invalid";
       if (req.state === oracle.types.state.RequestState.Requested)

--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from "react";
 import { ICell, IRow } from "../table/Table";
-import { DateTime } from "luxon";
 import { ethers } from "ethers";
 import { CHAINS, ChainId } from "constants/blockchain";
-import { parseIdentifier } from "helpers/format";
+import { parseIdentifier, formatTime } from "helpers/format";
 
 const hc: ICell[] = [
   {
@@ -149,11 +148,7 @@ function useRequestTableData({
         },
         {
           size: "lg",
-          value: timestamp
-            ? `${DateTime.fromSeconds(timestamp).toFormat(
-                "LLL. dd yyyy hh:mm:ss"
-              )} (${timestamp})`
-            : "",
+          value: timestamp ? `${formatTime(timestamp)} (${timestamp})` : "",
         },
       ],
     });

--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { ICell, IRow } from "../table/Table";
 import { ethers } from "ethers";
 import { CHAINS, ChainId } from "constants/blockchain";
-import { parseIdentifier, formatTime } from "helpers/format";
+import { parseIdentifier, formatTime, formatDate } from "helpers/format";
 
 const hc: ICell[] = [
   {
@@ -148,7 +148,15 @@ function useRequestTableData({
         },
         {
           size: "lg",
-          value: timestamp ? `${formatTime(timestamp)} (${timestamp})` : "",
+          value: timestamp ? (
+            <div>
+              {formatDate(timestamp)}
+              <br />
+              {formatTime(timestamp)} ({timestamp})
+            </div>
+          ) : (
+            ""
+          ),
         },
       ],
     });

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -103,6 +103,9 @@ export function formatRequestTitle(params: FormatRequestTitleParams) {
   return title;
 }
 
+export function formatDate(timestamp: number | string) {
+  return DateTime.fromSeconds(Number(timestamp)).toFormat("LLL. dd yyyy");
+}
 export function formatTime(timestamp: number | string) {
-  return DateTime.fromSeconds(Number(timestamp)).toFormat("LLL. dd yyyy ttt");
+  return DateTime.fromSeconds(Number(timestamp)).toFormat("ttt");
 }

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { DateTime } from "luxon";
 
 export const prettyFormatNumber = Intl.NumberFormat("en-US").format;
 
@@ -100,4 +101,8 @@ export function formatRequestTitle(params: FormatRequestTitleParams) {
     console.error("Error Formatting Request Title", err, params);
   }
   return title;
+}
+
+export function formatTime(timestamp: number | string) {
+  return DateTime.fromSeconds(Number(timestamp)).toFormat("LLL. dd yyyy ttt");
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Previous timestamp was shown in 12 hour am/pm local time. Now its shown in 24 hour UTC time with the zone displayed. 

Edit: This was requested to remain in local 12 hour time with am/pm and show zone. 

before:
![image](https://user-images.githubusercontent.com/4429761/157683603-f8e95803-92a1-48d6-ac32-2a2f0304691c.png)

after:
![image](https://user-images.githubusercontent.com/4429761/157685242-3eca50a1-dcd7-46fe-8696-e30fcc51baab.png)
![image](https://user-images.githubusercontent.com/4429761/157685325-fd368777-dad9-4641-943b-fb31499e1989.png)


note that previously the time was local to you, now it will be offset by the utc zone