### PR TITLE
fix: rename disput to dispute

### DIFF
--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -53,7 +53,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
       if (req.state === oracle.types.state.RequestState.Disputed)
         requestState = (
           <span>
-            <AlertLogo src={alertIcon} alt="alert_icon" /> Disput{" "}
+            <AlertLogo src={alertIcon} alt="alert_icon" /> Dispute{" "}
           </span>
         );
       if (req.state === oracle.types.state.RequestState.Settled)


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This was not tested, but was the only instance where dispute was misspelled