### PR TITLE
fix: improve error messages

### DIFF
--- a/src/components/request/RequestForm.tsx
+++ b/src/components/request/RequestForm.tsx
@@ -116,11 +116,24 @@ const RequestForm: FC = () => {
 
   useEffect(() => {
     if (flags.InsufficientBalance) {
-      setInputError("You don't have enough funds to approve the bond.");
+      if (flags.CanPropose) {
+        setInputError(
+          `You don't have enough ${collateralSymbol} to propose an answer.`
+        );
+      } else if (flags.CanDispute) {
+        setInputError(
+          `You don't have enough ${collateralSymbol} to dispute this proposal.`
+        );
+      }
     } else {
       setInputError("");
     }
-  }, [flags.InsufficientBalance]);
+  }, [
+    flags.InsufficientBalance,
+    collateralSymbol,
+    flags.CanPropose,
+    flags.CanDispute,
+  ]);
 
   const getDisputeButtonProps = () => {
     // setInputError("");


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Error message now changes based on what status the request is in. 
![image](https://user-images.githubusercontent.com/4429761/157745102-8a0a5890-ac8c-4f86-a9cc-6baf1ec8b454.png)

![image](https://user-images.githubusercontent.com/4429761/157745524-ad4e019b-1b03-49c8-807e-6924597e6c24.png)
