### PR TITLE
fix: handle unanswerable requests

### DIFF
--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -70,7 +70,6 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
 
       if (req.proposedPrice && unanswerable.includes(req.proposedPrice)) {
         proposedPrice = "Unanswerable";
-        console.log(req.proposedPrice);
       } else if (
         req.proposedPrice &&
         req.proposedPrice !== "0" &&

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -6,6 +6,10 @@ import { ethers } from "ethers";
 import { formatRequestTitle, formatTime, formatDate } from "helpers/format";
 import alertIcon from "assets/alert-icon.svg";
 
+const unanswerable = [
+  "-57896044618658097711785492504343953926634992332820282019728792003956564819968"
+];
+
 const headerCells: ICell[] = [
   {
     size: "lg",
@@ -64,8 +68,9 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
 
       let proposedPrice = req.proposedPrice;
 
-      if (req.proposedPrice && req.proposedPrice.startsWith("-")) {
+      if (req.proposedPrice && unanswerable.includes(req.proposedPrice)) {
         proposedPrice = "Unanswerable";
+        console.log(req.proposedPrice);
       } else if (
         req.proposedPrice &&
         req.proposedPrice !== "0" &&

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -69,7 +69,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
       let proposedPrice = req.proposedPrice;
 
       if (req.proposedPrice && unanswerable.includes(req.proposedPrice)) {
-        proposedPrice = "Unanswerable";
+        proposedPrice = "Requested too early";
       } else if (
         req.proposedPrice &&
         req.proposedPrice !== "0" &&

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -63,15 +63,16 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
         requestState = "Settled";
 
       let proposedPrice = req.proposedPrice;
-      if (
+
+      if (req.proposedPrice && req.proposedPrice.startsWith("-")) {
+        proposedPrice = "Unanswerable";
+      } else if (
         req.proposedPrice &&
         req.proposedPrice !== "0" &&
         identifier !== "YES_OR_NO_QUERY"
       ) {
         proposedPrice = ethers.utils.formatEther(req.proposedPrice);
-      }
-
-      if (
+      } else if (
         req.proposedPrice &&
         parseIdentifier(req.identifier) === "YES_OR_NO_QUERY"
       ) {


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

Show "Unanswerable" instead of long string of characters. I filtered the requests by checking if the `proposedPrice` starts with "-". Idk if it is the right approach

<img width="1341" alt="Screenshot 2022-04-13 at 04 52 06" src="https://user-images.githubusercontent.com/89395931/163083847-44afabdb-c76d-4b98-8c6b-dda668a9e0eb.png">

---

<img width="1340" alt="Screenshot 2022-04-13 at 04 55 06" src="https://user-images.githubusercontent.com/89395931/163084109-0ad70db1-1bdf-4af2-9a60-5ec25a5c1a1b.png">

