### PR TITLE
feat: add kovan option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 - REACT_APP_ONBOARD_API_KEY
 
+## Optional Environment Variables
+
+At least one of these providers should be enabled in order for the app to collect any data. 
+
 - REACT_APP_PROVIDER_URL_1 (Ethereum Provider)
 
 - REACT_APP_PROVIDER_URL_137 (Polygon Provider)
 
-## Optional Environment Variables
+- REACT_APP_PROVIDER_URL_42 (Eth Kovan Provider)
 
-- REACT_APP_DEBUG=1 enable event state debugging output to console. Remove definition in production.
+- REACT_APP_DEBUG=1 enable event state debugging output to console. Remove definition in production. Setting debug to 1 will also enable local hardhat testing with chain id 1337.
 
 # Getting Started with Create React App
 

--- a/src/constants/blockchain.ts
+++ b/src/constants/blockchain.ts
@@ -19,6 +19,7 @@ type ChainMetadata = {
 
 export enum ChainId {
   MAINNET = 1,
+  KOVAN = 42,
   POLYGON = 137,
   MM_TESTNET = 1337,
   HARDHAT = 31337,
@@ -32,6 +33,19 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
     explorerUrl: "https://etherscan.io",
     constructExplorerLink: (txHash: string) =>
       `https://etherscan.io/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Ether",
+      symbol: "ETH",
+      decimals: 18,
+    },
+  },
+  [ChainId.KOVAN]: {
+    name: "Kovan Ethereum",
+    chainId: ChainId.KOVAN,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://kovan.etherscan.io",
+    constructExplorerLink: (txHash: string) =>
+      `https://kovan.etherscan.io/tx/${txHash}`,
     nativeCurrency: {
       name: "Ether",
       symbol: "ETH",

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -1,40 +1,52 @@
 import { oracle } from "@uma/sdk";
 import { CHAINS, ChainId } from "./blockchain";
 
+// metamask local chain for testing
+const mmChainId = 1337;
 // Ethereum config
 const ethChainId = ChainId.MAINNET;
-const ethChainConfig: oracle.types.state.PartialChainConfig = {
-  rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1 ?? ""],
-  nativeCurrency: CHAINS[ethChainId].nativeCurrency,
-  chainName: CHAINS[ethChainId].name,
-  blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
-};
-
 // Polygon config
 const polygonChainId = ChainId.POLYGON;
-const polygonChainConfig: oracle.types.state.PartialChainConfig = {
-  rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137 ?? ""],
-  nativeCurrency: CHAINS[polygonChainId].nativeCurrency,
-  chainName: CHAINS[polygonChainId].name,
-  blockExplorerUrls: [CHAINS[polygonChainId].explorerUrl],
-};
+const kovanChainId = ChainId.KOVAN;
 
-const mmChainId = 1337;
-const mmChainConfig: oracle.types.state.PartialChainConfig = {
-  nativeCurrency: CHAINS[ethChainId].nativeCurrency,
-  blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
-  chainName: CHAINS[ethChainId].name,
-  multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
-  optimisticOracleAddress: "0xC43767F4592DF265B4a9F1a398B97fF24F38C6A6",
-  rpcUrls: ["http://127.0.0.1:8545"],
-};
+const chains: Record<number, oracle.types.state.PartialChainConfig> = {};
 
-const config = {
-  chains: {
-    [polygonChainId]: polygonChainConfig,
-    [ethChainId]: ethChainConfig,
-    [mmChainId]: mmChainConfig,
-  },
-};
+// enable local node if debug is on
+if (process.env.REACT_APP_DEBUG) {
+  chains[mmChainId] = {
+    rpcUrls: ["http://127.0.0.1:8545"],
+    nativeCurrency: CHAINS[ethChainId].nativeCurrency,
+    blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
+    chainName: CHAINS[ethChainId].name,
+    multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+    optimisticOracleAddress: "0xC43767F4592DF265B4a9F1a398B97fF24F38C6A6",
+  };
+}
 
-export default config;
+if (process.env.REACT_APP_PROVIDER_URL_1) {
+  chains[ethChainId] = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1],
+    nativeCurrency: CHAINS[ethChainId].nativeCurrency,
+    chainName: CHAINS[ethChainId].name,
+    blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
+  };
+}
+
+if (process.env.REACT_APP_PROVIDER_URL_137) {
+  chains[polygonChainId] = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137],
+    nativeCurrency: CHAINS[polygonChainId].nativeCurrency,
+    chainName: CHAINS[polygonChainId].name,
+    blockExplorerUrls: [CHAINS[polygonChainId].explorerUrl],
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_42) {
+  chains[kovanChainId] = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42],
+    nativeCurrency: CHAINS[kovanChainId].nativeCurrency,
+    chainName: CHAINS[kovanChainId].name,
+    blockExplorerUrls: [CHAINS[kovanChainId].explorerUrl],
+  };
+}
+
+export default { chains };

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -2,7 +2,7 @@ import { oracle } from "@uma/sdk";
 import { CHAINS, ChainId } from "./blockchain";
 
 // metamask local chain for testing
-const mmChainId = 1337;
+const mmChainId = ChainId.MM_TESTNET;
 // Ethereum config
 const ethChainId = ChainId.MAINNET;
 // Polygon config

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,12 +7,7 @@ import reportWebVitals from "./reportWebVitals";
 import { BrowserRouter } from "react-router-dom";
 
 // Make sure environment variables are defined.
-const ethProvider = process.env.REACT_APP_PROVIDER_URL_1;
 const onboardKey = process.env.REACT_APP_ONBOARD_API_KEY;
-const polygonProvider = process.env.REACT_APP_PROVIDER_URL_137;
-
-assert(ethProvider, "Requires REACT_APP_PROVIDER_URL_1");
-assert(polygonProvider, "Requires REACT_APP_PROVIDER_URL_137");
 assert(onboardKey, "Requires REACT_APP_ONBOARD_API_KEY");
 
 ReactDOM.render(


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This makes a few changes to the config. To enable a specific chain, you must provider the provider url with the chain id. Enabling kovan after this update will require environment vars to add a kovan provider. Also the testing chain is disabled by removing REACT_APP_DEBUG. Previously it could not be disabled.