### PR TITLE
fix: modify filter buttons

### DIFF
--- a/src/components/index/Index.styled.tsx
+++ b/src/components/index/Index.styled.tsx
@@ -95,45 +95,6 @@ export const FilterButton = styled(Button)`
   &:first-of-type {
     margin-left: 16px;
   }
-  &:last-of-type {
-    background-color: #f5f4f4;
-    color: #272528;
-    margin-left: auto;
-    width: 200px;
-    margin-right: 8px;
-    input[type="checkbox"] {
-      display: none;
-    }
-    input[type="checkbox"] + span {
-      display: inline-block;
-      position: relative;
-      width: 18px;
-      height: 18px;
-      vertical-align: middle;
-      background: #fff left top no-repeat;
-      border: 1px solid #ccc;
-      cursor: pointer;
-      > span {
-        display: none;
-      }
-    }
-    input[type="checkbox"]:checked + span {
-      background: #ff4d4d -19px top no-repeat;
-      span:first-of-type {
-        position: absolute;
-        display: block;
-        left: 6px;
-        top: 2px;
-        width: 5px;
-        height: 10px;
-        border: solid white;
-        border-width: 0 3px 3px 0;
-        -webkit-transform: rotate(45deg);
-        -ms-transform: rotate(45deg);
-        transform: rotate(45deg);
-      }
-    }
-  }
 `;
 
 interface IFilterNumbers {

--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -60,7 +60,6 @@ const Index = ({
   const { state } = useClient();
   const { descendingRequests } = useReader(state);
   const [filteredRequests, setFilteredRequests] = useState(initialFR);
-  const [checked, setChecked] = useState<boolean>(false);
 
   useEffect(() => {
     if (!descendingRequests) return;
@@ -100,17 +99,17 @@ const Index = ({
     setFilteredRequests(nextFR);
   }, [descendingRequests]);
 
-  function filterDescendingRequests(checked: boolean, filter: Filter) {
+  function filterDescendingRequests(filter: Filter) {
     let fr: RequestIndex[] = [];
     if (filter === Filter.PROPOSED) fr = filteredRequests.proposed;
     if (filter === Filter.REQUESTS) fr = filteredRequests.requested;
     if (filter === Filter.DISPUTED) fr = filteredRequests.disputed;
+    if (filter === Filter.ANSWERED) fr = filteredRequests.answered;
     if (filter === Filter.DEFAULT) fr = filteredRequests.all;
-    if (!checked) fr = [...fr, ...filteredRequests.answered];
     return fr.sort((a, b) => b.timestamp - a.timestamp);
   }
 
-  const filteredDescendingRequests = filterDescendingRequests(checked, filter);
+  const filteredDescendingRequests = filterDescendingRequests(filter);
 
   return (
     <Wrapper>
@@ -127,7 +126,6 @@ const Index = ({
             variant={filter === Filter.DEFAULT ? "primary" : "outline"}
             onClick={() => {
               setFilter(Filter.DEFAULT);
-              if (checked) setChecked(false);
             }}
           >
             <div>All</div>{" "}
@@ -139,7 +137,6 @@ const Index = ({
             variant={filter === Filter.REQUESTS ? "primary" : "outline"}
             onClick={() => {
               setFilter(Filter.REQUESTS);
-              setChecked(true);
             }}
           >
             <div>Requests </div>{" "}
@@ -151,7 +148,6 @@ const Index = ({
             variant={filter === Filter.PROPOSED ? "primary" : "outline"}
             onClick={() => {
               setFilter(Filter.PROPOSED);
-              setChecked(true);
             }}
           >
             <div>Proposed </div>{" "}
@@ -163,7 +159,6 @@ const Index = ({
             variant={filter === Filter.DISPUTED ? "primary" : "outline"}
             onClick={() => {
               setFilter(Filter.DISPUTED);
-              setChecked(true);
             }}
           >
             <div>Disputed </div>{" "}
@@ -172,22 +167,15 @@ const Index = ({
             </FilterNumbers>
           </FilterButton>
           <FilterButton
-            onClick={() => setChecked((prevValue) => !prevValue)}
-            variant="base"
+            variant={filter === Filter.ANSWERED ? "primary" : "outline"}
+            onClick={() => {
+              setFilter(Filter.ANSWERED);
+            }}
           >
-            <input
-              checked={checked}
-              type="checkbox"
-              onChange={(event) => setChecked(event.target.checked)}
-            />
-            <span>
-              <span />
-              <span />
-            </span>
-            <ShowAnsweredText>Hide Settled</ShowAnsweredText>
-            <ShowAnsweredText>
+            <div>Settled </div>{" "}
+            <FilterNumbers selected={filter === Filter.ANSWERED}>
               {addCommasOnly(filteredRequests.answered.length)}
-            </ShowAnsweredText>
+            </FilterNumbers>
           </FilterButton>
         </FilterButtonRow>
       </FilterWrapper>
@@ -205,7 +193,7 @@ const Index = ({
 };
 
 function ALL_FILTER(x: RequestIndex) {
-  return REQUEST_FILTER(x) || PROPOSED_FILTER(x) || DISPUTE_FILTER(x);
+  return REQUEST_FILTER(x) || PROPOSED_FILTER(x) || DISPUTE_FILTER(x) || ANSWERED_FILTER(x);
 }
 
 function PROPOSED_FILTER(x: RequestIndex) {

--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -10,7 +10,6 @@ import {
   FilterButton,
   FilterWrapper,
   FilterNumbers,
-  ShowAnsweredText,
 } from "./Index.styled";
 import ooLogo from "assets/uma-oo-logo-redcirclebg.svg";
 import useClient from "hooks/useOracleClient";


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

Make the filter buttons on homepage more intuitive by adding a separate button for filtering Settled items. 

<img width="1198" alt="Screenshot 2022-05-05 at 15 17 05" src="https://user-images.githubusercontent.com/89395931/166921348-beeddbed-8e0b-44d0-a1b1-d68345f67ace.png">
