### PR TITLE
fix: make title parsing a bit more permissive

### DIFF
--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -192,7 +192,12 @@ const Index = ({
 };
 
 function ALL_FILTER(x: RequestIndex) {
-  return REQUEST_FILTER(x) || PROPOSED_FILTER(x) || DISPUTE_FILTER(x) || ANSWERED_FILTER(x);
+  return (
+    REQUEST_FILTER(x) ||
+    PROPOSED_FILTER(x) ||
+    DISPUTE_FILTER(x) ||
+    ANSWERED_FILTER(x)
+  );
 }
 
 function PROPOSED_FILTER(x: RequestIndex) {

--- a/src/components/request/useSettledTableData.tsx
+++ b/src/components/request/useSettledTableData.tsx
@@ -32,7 +32,7 @@ function useSettledTableData(
         }
       }
     } catch (err: any) {
-      console.log("Error in parsing identifier", err.message);
+      console.error("Error in parsing identifier", err.message);
     }
 
     let nextRows = [

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -39,8 +39,8 @@ export function parseAncillaryData(ancillaryData: string) {
 
 export function validateYesNoQueryString(parsedAncillaryData: string) {
   return (
-    parsedAncillaryData.includes("title: ") &&
-    parsedAncillaryData.includes("description: ")
+    parsedAncillaryData.includes("title:") &&
+    parsedAncillaryData.includes("description:")
   );
 }
 
@@ -51,7 +51,7 @@ export function formatYesNoQueryString(
   maxLength = MAX_TITLE_LENGTH
 ) {
   // Split the string before title:
-  const splitOne = str.split("title: ")[1];
+  const splitOne = str.split("title:")[1].trim();
 
   // Remove the string after description:
   const title = splitOne.split("description:")[0].replace(/[^\x20-\x7E]+/g, "");


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

Titles werent being parsed when they didnt include a space after the colon in "description:" in the ancillary data.