### PR TITLE
feat: integrate new oracle client and skinny requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^17.0.20",
     "@types/react-dom": "^17.0.9",
-    "@uma/sdk": "^0.23.2",
+    "@uma/sdk": "^0.26.0",
     "bnc-onboard": "^1.37.0",
     "downshift": "^6.1.7",
     "ethers": "^5.4.2",
@@ -29,6 +29,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",
+    "superstruct": "^0.16.0",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -8,14 +8,13 @@ import NotFound from "components/not-found";
 import Index from "components/index";
 import ChangeNetwork from "components/change-network/ChangeNetwork";
 import useConnection from "hooks/useConnection";
-import useClient from "hooks/useOracleClient";
-import useRequestParams from "hooks/useRequestParams";
+import { forEach } from "helpers/oracleClient";
+import { useRequestInputRequired } from "hooks/useRequestParams";
 import { OptionType } from "components/select/Select";
 import { items } from "components/index/RequestsTableWithPagination";
 const Router = () => {
   const { wrongNetwork } = useConnection();
-  const { client } = useClient();
-  const { request } = useRequestParams();
+  const requestQuery = useRequestInputRequired();
   // pulled this into router so that you dont lose your page number when you go to details page.
   const [currentPage, setCurrentPage] = useState<number>(0);
   const [dropdownPaginationValue, setDropdownPaginationValue] =
@@ -23,10 +22,10 @@ const Router = () => {
   return (
     <>
       <GlobalStyles />
-      {wrongNetwork && request && (
+      {wrongNetwork && requestQuery?.chainId && (
         <ChangeNetwork
-          switchChain={() => client.switchOrAddChain()}
-          chainId={request.chainId}
+          switchChain={() => forEach((client) => client.switchOrAddChain())}
+          chainId={requestQuery.chainId}
         />
       )}
       <Navbar />

--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -15,7 +15,7 @@ import ooLogo from "assets/uma-oo-logo-redcirclebg.svg";
 import useClient from "hooks/useOracleClient";
 import useReader from "hooks/useOracleReader";
 import { RequestState } from "constants/blockchain";
-import { RequestIndex } from "@uma/sdk/dist/types/oracle/types/state";
+import { oracle } from "helpers/oracleClient";
 import { addCommasOnly } from "utils/format";
 import { RequestsTableWithPagination } from "./RequestsTableWithPagination";
 import { OptionType } from "components/select/Select";
@@ -27,12 +27,15 @@ enum Filter {
   ANSWERED,
 }
 
+type Requests = oracle.types.interfaces.Requests;
+type Request = oracle.types.interfaces.Request;
+
 interface FilteredRequests {
-  all: RequestIndex[];
-  requested: RequestIndex[];
-  proposed: RequestIndex[];
-  disputed: RequestIndex[];
-  answered: RequestIndex[];
+  all: Requests;
+  requested: Requests;
+  proposed: Requests;
+  disputed: Requests;
+  answered: Requests;
 }
 
 const initialFR: FilteredRequests = {
@@ -59,6 +62,7 @@ const Index = ({
   const { state } = useClient();
   const { descendingRequests } = useReader(state);
   const [filteredRequests, setFilteredRequests] = useState(initialFR);
+  console.log({ descendingRequests, filteredRequests, state });
 
   useEffect(() => {
     if (!descendingRequests) return;
@@ -99,7 +103,7 @@ const Index = ({
   }, [descendingRequests]);
 
   function filterDescendingRequests(filter: Filter) {
-    let fr: RequestIndex[] = [];
+    let fr: Requests = [];
     if (filter === Filter.PROPOSED) fr = filteredRequests.proposed;
     if (filter === Filter.REQUESTS) fr = filteredRequests.requested;
     if (filter === Filter.DISPUTED) fr = filteredRequests.disputed;
@@ -191,7 +195,7 @@ const Index = ({
   );
 };
 
-function ALL_FILTER(x: RequestIndex) {
+function ALL_FILTER(x: Request) {
   return (
     REQUEST_FILTER(x) ||
     PROPOSED_FILTER(x) ||
@@ -200,19 +204,19 @@ function ALL_FILTER(x: RequestIndex) {
   );
 }
 
-function PROPOSED_FILTER(x: RequestIndex) {
+function PROPOSED_FILTER(x: Request) {
   return x.state === RequestState.Proposed;
 }
 
-function REQUEST_FILTER(x: RequestIndex) {
+function REQUEST_FILTER(x: Request) {
   return x.state === RequestState.Requested;
 }
 
-function DISPUTE_FILTER(x: RequestIndex) {
+function DISPUTE_FILTER(x: Request) {
   return x.state === RequestState.Disputed || x.state === RequestState.Resolved;
 }
 
-function ANSWERED_FILTER(x: RequestIndex) {
+function ANSWERED_FILTER(x: Request) {
   return x.state === RequestState.Settled;
 }
 

--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -62,7 +62,6 @@ const Index = ({
   const { state } = useClient();
   const { descendingRequests } = useReader(state);
   const [filteredRequests, setFilteredRequests] = useState(initialFR);
-  console.log({ descendingRequests, filteredRequests, state });
 
   useEffect(() => {
     if (!descendingRequests) return;

--- a/src/components/index/RequestsTable.tsx
+++ b/src/components/index/RequestsTable.tsx
@@ -7,10 +7,11 @@ import {
 } from "./RequestsTable.styled";
 
 import createRequestsTableCells from "./createRequestsTableCells";
-import { RequestIndexes } from "@uma/sdk/dist/types/oracle/types/state";
+import { oracle } from "@uma/sdk";
+type Requests = oracle.types.state.RequestsWithOracleType;
 
 interface Props {
-  requests: RequestIndexes;
+  requests: Requests;
 }
 const RequestsTable: React.FC<Props> = ({ requests }) => {
   const { headerCells, rows } = createRequestsTableCells(requests);

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -33,7 +33,9 @@ const headerCells: ICell[] = [
   },
 ];
 
-function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
+function createRequestsTableCells(
+  requests: oracle.types.state.RequestsWithOracleType
+) {
   const rows = [] as IRow[];
 
   if (requests.length) {
@@ -66,21 +68,23 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
       if (req.state === oracle.types.state.RequestState.Settled)
         requestState = "Settled";
 
-      let proposedPrice = req.proposedPrice;
+      let proposedPrice = req.proposedPrice
+        ? req.proposedPrice.toString()
+        : undefined;
 
-      if (req.proposedPrice && unanswerable.includes(req.proposedPrice)) {
+      if (proposedPrice && unanswerable.includes(proposedPrice)) {
         proposedPrice = "Requested too early";
       } else if (
-        req.proposedPrice &&
-        req.proposedPrice !== "0" &&
+        proposedPrice &&
+        proposedPrice !== "0" &&
         identifier !== "YES_OR_NO_QUERY"
       ) {
-        proposedPrice = ethers.utils.formatEther(req.proposedPrice);
+        proposedPrice = ethers.utils.formatEther(proposedPrice);
       } else if (
-        req.proposedPrice &&
+        proposedPrice &&
         parseIdentifier(req.identifier) === "YES_OR_NO_QUERY"
       ) {
-        const formattedPrice = ethers.utils.formatEther(req.proposedPrice);
+        const formattedPrice = ethers.utils.formatEther(proposedPrice);
         if (formattedPrice === "0.0") proposedPrice = "No";
         if (formattedPrice === "1.0") proposedPrice = "Yes";
         if (formattedPrice === "0.5") proposedPrice = "Indeterminate";
@@ -91,9 +95,7 @@ function createRequestsTableCells(requests: oracle.types.state.RequestIndexes) {
           size: "lg",
           value: (
             <StyledLink
-              to={`/request?requester=${req.requester}
-            &identifier=${req.identifier}&ancillaryData=${req.ancillaryData}&timestamp=${req.timestamp}&chainId=${req.chainId}
-            `}
+              to={`/request?requester=${req.requester}&identifier=${req.identifier}&ancillaryData=${req.ancillaryData}&timestamp=${req.timestamp}&chainId=${req.chainId}&oracleType=${req.oracleType}`}
             >
               {identifier}
             </StyledLink>

--- a/src/components/request/Request.tsx
+++ b/src/components/request/Request.tsx
@@ -50,9 +50,10 @@ const Request = () => {
   });
 
   useEffect(() => {
+    if (!client) return;
     const request: unknown = Object.fromEntries([...searchParams]);
-    let requestByTx = getRequestInputByTransaction(request);
-    if (client && requestByTx) {
+    try {
+      let requestByTx = getRequestInputByTransaction(request);
       setRequestId(
         client.setActiveRequestByTransaction({
           chainId: requestByTx.chainId,
@@ -60,9 +61,11 @@ const Request = () => {
           eventIndex: requestByTx.eventIndex ?? 0,
         })
       );
+    } catch (err) {
+      console.warn("parsing query by transaction", err);
     }
-    const requestInput = getRequestInput(request);
-    if (client && requestInput) {
+    try {
+      const requestInput = getRequestInput(request);
       setRequestId(
         client.setActiveRequest({
           requester: requestInput.requester.trim(),
@@ -72,6 +75,8 @@ const Request = () => {
           chainId: requestInput.chainId,
         })
       );
+    } catch (err) {
+      console.warn("parsing query by input", err);
     }
   }, [client, searchParams]);
 

--- a/src/components/request/RequestHero.tsx
+++ b/src/components/request/RequestHero.tsx
@@ -17,6 +17,8 @@ import {
 import { CHAINS, ChainId } from "constants/blockchain";
 import useClient from "hooks/useOracleClient";
 import useReader from "hooks/useOracleReader";
+import { oracle } from "helpers/oracleClient";
+
 import alertIcon from "assets/alert-icon.svg";
 import { formatRequestTitle } from "helpers/format";
 
@@ -32,14 +34,14 @@ const RequestHero: FC<Props> = ({ chainId }) => {
     logo = CHAINS[chainId].logoURI;
     chainName = CHAINS[chainId].name;
   }
-  const { oracle, state } = useClient();
+  const { state } = useClient();
   const {
     requestState,
     requestTx,
     exploreRequestTx,
     identifier,
     ancillaryData,
-  } = useReader(state);
+  } = useReader(state || {});
 
   return (
     <HeroSection>

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -9,11 +9,14 @@ const ethChainId = ChainId.MAINNET;
 const polygonChainId = ChainId.POLYGON;
 const kovanChainId = ChainId.KOVAN;
 const bobaChainId = ChainId.BOBA;
-const chains: Record<number, oracle.types.state.PartialChainConfig> = {};
+
+const optimisticChains: Record<number, oracle.types.state.PartialChainConfig> =
+  {};
+const skinnyChains: Record<number, oracle.types.state.PartialChainConfig> = {};
 
 // enable local node if debug is on
 if (process.env.REACT_APP_DEBUG) {
-  chains[mmChainId] = {
+  optimisticChains[mmChainId] = {
     rpcUrls: ["http://127.0.0.1:8545"],
     nativeCurrency: CHAINS[ethChainId].nativeCurrency,
     blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
@@ -24,16 +27,18 @@ if (process.env.REACT_APP_DEBUG) {
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_1) {
-  chains[ethChainId] = {
+  const chainConfig: oracle.types.state.PartialChainConfig = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1],
     nativeCurrency: CHAINS[ethChainId].nativeCurrency,
     chainName: CHAINS[ethChainId].name,
     blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
   };
+  optimisticChains[ethChainId] = chainConfig;
+  skinnyChains[ethChainId] = chainConfig;
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_137) {
-  chains[polygonChainId] = {
+  optimisticChains[polygonChainId] = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137],
     nativeCurrency: CHAINS[polygonChainId].nativeCurrency,
     chainName: CHAINS[polygonChainId].name,
@@ -47,7 +52,7 @@ if (process.env.REACT_APP_PROVIDER_URL_137) {
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_42) {
-  chains[kovanChainId] = {
+  optimisticChains[kovanChainId] = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42],
     nativeCurrency: CHAINS[kovanChainId].nativeCurrency,
     chainName: CHAINS[kovanChainId].name,
@@ -56,7 +61,7 @@ if (process.env.REACT_APP_PROVIDER_URL_42) {
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_288) {
-  chains[bobaChainId] = {
+  optimisticChains[bobaChainId] = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_288],
     nativeCurrency: CHAINS[bobaChainId].nativeCurrency,
     chainName: CHAINS[bobaChainId].name,
@@ -64,5 +69,12 @@ if (process.env.REACT_APP_PROVIDER_URL_288) {
   };
 }
 
-const config = { chains };
+// order of export is important, this determines the order in which clients are returned from factory
+const config: [
+  oracle.types.state.OracleType,
+  oracle.types.state.PartialConfig
+][] = [
+  [oracle.types.state.OracleType.Optimistic, { chains: optimisticChains }],
+  [oracle.types.state.OracleType.Skinny, { chains: skinnyChains }],
+];
 export default config;

--- a/src/helpers/onboard.ts
+++ b/src/helpers/onboard.ts
@@ -1,6 +1,6 @@
 import Onboard from "bnc-onboard";
 import { ethers } from "ethers";
-import { client, oracle } from "./oracleClient";
+import { oracle, forEach } from "./oracleClient";
 import onboardBaseConfig from "./onboardBaseConfig";
 import { Wallet } from "bnc-onboard/dist/src/interfaces";
 
@@ -13,7 +13,9 @@ export const onboard = Onboard({
     address: (address: string) => {
       debug && console.log("onboard address change", address);
       if (address) {
-        client.setUser({ address: ethers.utils.getAddress(address) });
+        forEach((client) => {
+          client.setUser({ address: ethers.utils.getAddress(address) });
+        });
       } else {
         // address is undefined when metamask wallet is logged out, so run the disconnect routine
         disconnect();
@@ -22,7 +24,7 @@ export const onboard = Onboard({
     network: (networkId: number) => {
       debug && console.log("onboard network change", networkId);
       if (!networkId) return;
-      const params: Parameters<typeof client.setUser>["0"] = {
+      const params: Partial<oracle.types.state.User> = {
         chainId: networkId,
       };
       if (currentWallet && currentWallet.provider) {
@@ -32,7 +34,9 @@ export const onboard = Onboard({
         params.provider.polling = false;
         params.signer = params.provider.getSigner();
       }
-      client.setUser(params);
+      forEach((client) => {
+        client.setUser(params);
+      });
     },
     wallet: async (wallet: Wallet) => {
       debug && console.log("onboard wallet change", wallet);
@@ -53,5 +57,7 @@ export const connect = async () => {
 };
 export const disconnect = () => {
   onboard.walletReset();
-  client.clearUser();
+  forEach((client) => {
+    client.clearUser();
+  });
 };

--- a/src/helpers/oracleClient.ts
+++ b/src/helpers/oracleClient.ts
@@ -2,18 +2,47 @@ import { oracle } from "@uma/sdk";
 import config from "constants/oracleConfig";
 import Events from "events";
 
+type OracleType = oracle.types.state.OracleType;
+type State = oracle.types.state.State;
+type Client = oracle.client.Client;
+
+export const isSupportedOracleType = oracle.utils.isSupportedOracleType;
+
 export { oracle };
+
+export type { OracleType, State, Client };
 export const events = new Events();
-export const client = oracle.client.factory(
-  config,
-  (state: oracle.types.state.State) => events.emit("change", state)
+export const clients = oracle.factory(
+  // the configs are an array of oracle configs, the order of the configs determine the order of clients returned
+  Object.fromEntries(config),
+  (oracleType: OracleType, state: State) =>
+    events.emit("change", oracleType, state)
 );
 
-// setting this to the fastest interval for more responsive state changes
-client.startInterval(1);
+// Iterate easily over all clients, useful for duplicating commands on clients
+export function forEach(cb: (client: Client) => void): void {
+  Object.values(clients).forEach(cb);
+}
+
+export function mapObject<V>(cb: (client: Client) => V): {
+  [key in OracleType]?: V;
+} {
+  return Object.fromEntries(
+    Object.entries(clients).map(([oracleType, client]) => {
+      return [oracleType, cb(client)];
+    })
+  );
+}
+
+export const defaultOracleType: OracleType = config[0][0];
+
+forEach((client) => {
+  // setting this to the fastest interval for more responsive state changes
+  client.startInterval(1);
+});
 
 if (process.env.REACT_APP_DEBUG) {
-  events.on("change", (state) => {
-    console.log("event change", state);
+  events.on("change", (index, state) => {
+    console.log("event change", index, state);
   });
 }

--- a/src/hooks/useOracleClient.ts
+++ b/src/hooks/useOracleClient.ts
@@ -1,15 +1,33 @@
 import React from "react";
+import assert from "assert";
 import { Context } from "context/OracleClientContext";
+import { oracle, defaultOracleType } from "helpers/oracleClient";
+import { useRequestInputRequired } from "hooks/useRequestParams";
 
-function useOracleClient() {
+function useOracleClient(oracleTypeOverride?: oracle.types.state.OracleType) {
   const context = React.useContext(Context);
-  if (!context) {
-    throw new Error(
-      "useOracleClient must be used within a <OracleClientProvider>"
-    );
-  }
+  assert(
+    context,
+    "useOracleClient must be used within a <OracleClientProvider>"
+  );
 
-  return context;
+  const requestQuery = useRequestInputRequired();
+
+  const oracleType =
+    oracleTypeOverride || requestQuery?.oracleType || defaultOracleType;
+  const client = context.clients[oracleType];
+  assert(client, "no client for oracle type: " + oracleType);
+
+  const state = context.states[oracleType];
+  assert(state, "no state for oracle type: " + oracleType);
+
+  const flags = context.oracle.utils.getFlags(state);
+
+  return {
+    client,
+    state,
+    flags,
+  };
 }
 
 export default useOracleClient;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -3,4 +3,8 @@ export const numberFormatter = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 4,
 }).format;
 
+export function capitalizeFirstLetter(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
 export const addCommasOnly = new Intl.NumberFormat("en-US").format;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3269,25 +3269,25 @@
     "@typescript-eslint/types" "5.10.0"
     eslint-visitor-keys "^3.0.0"
 
-"@uma/contracts-frontend@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.5.tgz#b50c5282cf8fc2a572db3a7d8e8243c9bbb6fca5"
-  integrity sha512-85q56CeC90/jibyx69aqFGJo+AHGdc17iij/RgJNkjNBq6nZVNJsJd3KGRziIeWeonQXj3srwDSPQtcsL5Borg==
+"@uma/contracts-frontend@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.10.tgz#3cb23d9bc61048c0c4847bd355b3cc7e53c51aff"
+  integrity sha512-IqjGy3xp0XiXTkhLC06OFOuKcSnQjKlllnvfxNYdKkLVz5JVbvptnveSqWkKsY2FUGDSsPNIG1CpYh/PL/AXKQ==
 
-"@uma/contracts-node@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.5.tgz#d5eddf736e7af08dff24b0c8b54bd1015f342970"
-  integrity sha512-/j3Yzl52ZQwt+suMNRAGcJf2Kq+unAv6f1DKVZIplfhaJSrHfgwl17YMR3k82knuRSxjJYyTGfYCOWHvsR1/AQ==
+"@uma/contracts-node@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.10.tgz#12f90873e83ba478b16c019d1c5d232e4d5ee782"
+  integrity sha512-jlWY1MIHu+kPEiV/JJaV+Mu5mCWWwEvXgnwNwdfSILKr6fn9sTk3HYPIMpt969794NbJg1RJAQshGXWPkFzhOA==
 
-"@uma/sdk@^0.23.2":
-  version "0.23.2"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.23.2.tgz#b4fe7cdacd9fd371e3e4473950f23878187aaeb6"
-  integrity sha512-nanWAk3kXvBqtqAA1yEEZFhDAnwia8hun8QLFLYZp73o9ry3v1fJPNtI9lm0wwqUVsXqLipnk2oMj2ui/kh89w==
+"@uma/sdk@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.26.0.tgz#a76d57a03e8b64bc141ecf082f676b7f7c1c0c2f"
+  integrity sha512-9nYoe2DKBJySKNCsPOWIy+8bTgW3FsFXzpjXfyNsO9ekX757leQ/GsAMN3k9qXkNgoqd/sWSAyHUIeHY6T46pw==
   dependencies:
     "@google-cloud/datastore" "^6.6.0"
     "@types/lodash-es" "^4.17.5"
-    "@uma/contracts-frontend" "^0.3.5"
-    "@uma/contracts-node" "^0.3.5"
+    "@uma/contracts-frontend" "^0.3.10"
+    "@uma/contracts-node" "^0.3.10"
     axios "^0.24.0"
     bn.js "^4.11.9"
     decimal.js "^10.3.1"
@@ -14354,6 +14354,11 @@ superagent@^3.8.3:
     mime "^1.4.1"
     qs "^6.5.1"
     readable-stream "^2.3.5"
+
+superstruct@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.16.0.tgz#9af5e059acd08e774789ad8880962427ef68dace"
+  integrity sha512-IDQtwnnlaan1NhuHqyD/U11lROYvCQ79JyfwlFU9xEVHzqV/Ys/RrwmHPCG0CVH/1g0BuodEjH1msxK2UHxehA==
 
 supports-color@^4.2.1:
   version "4.5.0"


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

### Summary
This adds support for skinny OO using the updated clients.  You will notice that the factory an identical client for each contract type, and we need to know if a request resides on the regular OO or skinny OO. That means when creating URLS externally we need a new field called `oracleType` which can be one of `Skinny` or `Optimistic`