### PR TITLE
feat: add support for many new chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@
 
 At least one of these providers should be enabled in order for the app to collect any data. 
 
-- REACT_APP_PROVIDER_URL_1 (Ethereum Provider)
-
-- REACT_APP_PROVIDER_URL_137 (Polygon Provider)
-
-- REACT_APP_PROVIDER_URL_42 (Eth Kovan Provider)
-
+- REACT_APP_PROVIDER_URL_1=Ethereum Provider
+- REACT_APP_PROVIDER_URL_5=Goerli Provider
+- REACT_APP_PROVIDER_URL_10=Optimism Provider
+- REACT_APP_PROVIDER_URL_82=Meter Provider
+- REACT_APP_PROVIDER_URL_100=xDai Provider
+- REACT_APP_PROVIDER_URL_137=Polygon Provider
+- REACT_APP_PROVIDER_URL_288=Boba Provider
+- REACT_APP_PROVIDER_URL_416=SX Provider
+- REACT_APP_PROVIDER_URL_9001=Evmos Provider
+- REACT_APP_PROVIDER_URL_42161=Arbitrum Provider
+- REACT_APP_PROVIDER_URL_43114=Avalanche Provider
 - REACT_APP_DEBUG=1 enable event state debugging output to console. Remove definition in production. Setting debug to 1 will also enable local hardhat testing with chain id 1337.
+- REACT_APP_FORK_1=1 enabled mainnet fork through local hardhat or other node, hard coded to http://127.0.0.1:8545 and chain 1337
+
 
 # Getting Started with Create React App
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^17.0.20",
     "@types/react-dom": "^17.0.9",
-    "@uma/sdk": "^0.27.0",
+    "@uma/sdk": "^0.27.1",
     "bnc-onboard": "^1.37.0",
     "downshift": "^6.1.7",
     "ethers": "^5.4.2",

--- a/src/components/index/IndexComponent.tsx
+++ b/src/components/index/IndexComponent.tsx
@@ -36,6 +36,7 @@ interface FilteredRequests {
   proposed: Requests;
   disputed: Requests;
   answered: Requests;
+  old: Requests;
 }
 
 const initialFR: FilteredRequests = {
@@ -44,6 +45,7 @@ const initialFR: FilteredRequests = {
   proposed: [],
   disputed: [],
   answered: [],
+  old: [],
 };
 
 interface Props {
@@ -66,6 +68,7 @@ const Index = ({
   useEffect(() => {
     if (!descendingRequests) return;
     const initial: FilteredRequests = {
+      old: [],
       all: [],
       requested: [],
       proposed: [],
@@ -78,6 +81,7 @@ const Index = ({
     const nextFR = descendingRequests.reduce((result, request) => {
       // skip requests older the 1 month
       if (request.timestamp < lastMonthTimestamp) {
+        result.old.push(request);
         return result;
       }
 
@@ -99,6 +103,11 @@ const Index = ({
       return result;
     }, initial);
     setFilteredRequests(nextFR);
+    if (process.env.REACT_APP_DEBUG && nextFR.old.length)
+      console.log(
+        `${nextFR.old.length} requests too old to show: `,
+        nextFR.old
+      );
   }, [descendingRequests]);
 
   function filterDescendingRequests(filter: Filter) {

--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -40,7 +40,8 @@ function createRequestsTableCells(
 
   if (requests.length) {
     requests.forEach((req) => {
-      const identifier = formatRequestTitle(req);
+      const title = formatRequestTitle(req);
+      const identifier = parseIdentifier(req.identifier);
       const timestamp = req.timestamp ? (
         <div>
           {formatDate(req.timestamp)}
@@ -72,7 +73,11 @@ function createRequestsTableCells(
         ? req.proposedPrice.toString()
         : undefined;
 
-      if (proposedPrice && unanswerable.includes(proposedPrice)) {
+      // req.state 1 is fresh request with no proposed answer, in that case always set to "-"
+      // proposed price sometimes defaults to 0 even if noone has proposed an answer yet.
+      if (req.state === undefined || req.state <= 1) {
+        proposedPrice = "-";
+      } else if (proposedPrice && unanswerable.includes(proposedPrice)) {
         proposedPrice = "Requested too early";
       } else if (
         proposedPrice &&
@@ -80,10 +85,7 @@ function createRequestsTableCells(
         identifier !== "YES_OR_NO_QUERY"
       ) {
         proposedPrice = ethers.utils.formatEther(proposedPrice);
-      } else if (
-        proposedPrice &&
-        parseIdentifier(req.identifier) === "YES_OR_NO_QUERY"
-      ) {
+      } else if (proposedPrice && identifier === "YES_OR_NO_QUERY") {
         const formattedPrice = ethers.utils.formatEther(proposedPrice);
         if (formattedPrice === "0.0") proposedPrice = "No";
         if (formattedPrice === "1.0") proposedPrice = "Yes";
@@ -97,7 +99,7 @@ function createRequestsTableCells(
             <StyledLink
               to={`/request?requester=${req.requester}&identifier=${req.identifier}&ancillaryData=${req.ancillaryData}&timestamp=${req.timestamp}&chainId=${req.chainId}&oracleType=${req.oracleType}`}
             >
-              {identifier}
+              {title}
             </StyledLink>
           ),
           cellClassName: "first-cell",

--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -216,7 +216,7 @@ function useRequestTableData({
     });
 
     let umipLink =
-      "https://docs.umaproject.org/uma-tokenholders/approved-price-identifiers";
+      "https://docs.umaproject.org/resources/approved-price-identifiers";
     if (convertedIdentifier === "YES_OR_NO_QUERY") {
       umipLink =
         "https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-107.md";

--- a/src/constants/blockchain.ts
+++ b/src/constants/blockchain.ts
@@ -21,13 +21,21 @@ type ChainMetadata = {
 export enum ChainId {
   MAINNET = 1,
   GOERLI = 5,
+  OPTIMISM = 10,
   KOVAN = 42,
+  METER = 82,
+  XDAI = 100,
   POLYGON = 137,
   BOBA = 288,
+  SX = 416,
   MM_TESTNET = 1337,
+  EVMOS = 9001,
+  ARBITRUM = 42161,
+  AVAX = 43114,
   HARDHAT = 31337,
 }
 
+// useful place to get most of this information: https://chainlist.org/
 export const CHAINS: Record<ChainId, ChainMetadata> = {
   [ChainId.MAINNET]: {
     name: "Ethereum",
@@ -55,6 +63,45 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
       decimals: 18,
     },
   },
+  [ChainId.OPTIMISM]: {
+    name: "Optimism",
+    chainId: ChainId.OPTIMISM,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://optimistic.etherscan.io",
+    constructExplorerLink: (txHash: string) =>
+      `https://optimistic.etherscan.io/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Ether",
+      symbol: "OETH",
+      decimals: 18,
+    },
+  },
+  [ChainId.METER]: {
+    name: "Meter",
+    chainId: ChainId.METER,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://scan.meter.io",
+    constructExplorerLink: (txHash: string) =>
+      `https://scan.meter.io/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Meter",
+      symbol: "MTR",
+      decimals: 18,
+    },
+  },
+  [ChainId.XDAI]: {
+    name: "xDai",
+    chainId: ChainId.XDAI,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://blockscout.com/xdai/mainnet",
+    constructExplorerLink: (txHash: string) =>
+      `https://blockscout.com/xdai/mainnet/tx/${txHash}`,
+    nativeCurrency: {
+      name: "xDai",
+      symbol: "XDAI",
+      decimals: 18,
+    },
+  },
   [ChainId.KOVAN]: {
     name: "Kovan Ethereum",
     chainId: ChainId.KOVAN,
@@ -72,7 +119,6 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
     name: "Polygon",
     chainId: ChainId.POLYGON,
     logoURI: polygonLogo,
-    rpcUrl: "https://polygon-rpc.com/",
     explorerUrl: "https://polygonscan.com",
     constructExplorerLink: (txHash: string) =>
       `https://polygonscan.com/tx/${txHash}`,
@@ -112,12 +158,64 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
     name: "Boba",
     chainId: ChainId.BOBA,
     logoURI: bobaLogo,
-    explorerUrl: "https://blockexplorer.boba.network/",
+    explorerUrl: "https://blockexplorer.boba.network",
     constructExplorerLink: (txHash: string) =>
       `https://blockexplorer.boba.network/tx/${txHash}`,
     nativeCurrency: {
       name: "Ether",
       symbol: "ETH",
+      decimals: 18,
+    },
+  },
+  [ChainId.SX]: {
+    name: "SX",
+    chainId: ChainId.SX,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://explorer.sx.technology",
+    constructExplorerLink: (txHash: string) =>
+      `https://explorer.sx.technology/tx/${txHash}`,
+    nativeCurrency: {
+      name: "SX",
+      symbol: "SX",
+      decimals: 18,
+    },
+  },
+  [ChainId.EVMOS]: {
+    name: "Evmos",
+    chainId: ChainId.EVMOS,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://evm.evmos.org",
+    constructExplorerLink: (txHash: string) =>
+      `https://evm.evmos.org/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Evmos",
+      symbol: "EVMOS",
+      decimals: 18,
+    },
+  },
+  [ChainId.ARBITRUM]: {
+    name: "Arbitrum",
+    chainId: ChainId.ARBITRUM,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://arbiscan.io",
+    constructExplorerLink: (txHash: string) =>
+      `https://arbiscan.io/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Ether",
+      symbol: "AETH",
+      decimals: 18,
+    },
+  },
+  [ChainId.AVAX]: {
+    name: "Avalanche",
+    chainId: ChainId.AVAX,
+    logoURI: ethereumLogo,
+    explorerUrl: "https://snowtrace.io",
+    constructExplorerLink: (txHash: string) =>
+      `https://snowtrace.io/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Avalanche",
+      symbol: "AVAX",
       decimals: 18,
     },
   },

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -1,16 +1,6 @@
 import { oracle } from "@uma/sdk";
 import { CHAINS, ChainId } from "./blockchain";
 
-// metamask local chain for testing
-const mmChainId = ChainId.MM_TESTNET;
-// Ethereum config
-const ethChainId = ChainId.MAINNET;
-// Polygon config
-const polygonChainId = ChainId.POLYGON;
-const kovanChainId = ChainId.KOVAN;
-const bobaChainId = ChainId.BOBA;
-const goerliChainId = ChainId.GOERLI;
-
 const optimisticChains: Record<number, oracle.types.state.PartialChainConfig> =
   {};
 const skinnyChains: Record<number, oracle.types.state.PartialChainConfig> = {};
@@ -20,81 +10,252 @@ const optimisticV2Chains: Record<
   oracle.types.state.PartialChainConfig
 > = {};
 
-// enable local node if debug is on
+// enable local node if debug is on, this only works as a fork of mainnet
 if (process.env.REACT_APP_DEBUG) {
-  optimisticChains[mmChainId] = {
+  const chainId = ChainId.MM_TESTNET;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
     rpcUrls: ["http://127.0.0.1:8545"],
-    nativeCurrency: CHAINS[ethChainId].nativeCurrency,
-    blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
-    chainName: CHAINS[ethChainId].name,
+    nativeCurrency: chain.nativeCurrency,
+    blockExplorerUrls: [chain.explorerUrl],
+    chainName: chain.name,
+  };
+  optimisticChains[chainId] = {
+    ...config,
     multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
     optimisticOracleAddress: "0xC43767F4592DF265B4a9F1a398B97fF24F38C6A6",
+  };
+  skinnyChains[chainId] = {
+    ...config,
+    multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+    optimisticOracleAddress: "0xeE3Afe347D5C74317041E2618C49534dAf887c24",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    multicall2Address: "0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696",
+    optimisticOracleAddress: "0xA0Ae6609447e57a42c51B50EAe921D701823FFAe",
   };
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_1) {
-  const chainConfig: oracle.types.state.PartialChainConfig = {
+  const chainId = ChainId.MAINNET;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1],
-    nativeCurrency: CHAINS[ethChainId].nativeCurrency,
-    chainName: CHAINS[ethChainId].name,
-    blockExplorerUrls: [CHAINS[ethChainId].explorerUrl],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
   };
-  optimisticChains[ethChainId] = chainConfig;
-  skinnyChains[ethChainId] = chainConfig;
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xc43767f4592df265b4a9f1a398b97ff24f38c6a6",
+  };
+  skinnyChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xeE3Afe347D5C74317041E2618C49534dAf887c24",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xA0Ae6609447e57a42c51B50EAe921D701823FFAe",
+  };
 }
 
+if (process.env.REACT_APP_PROVIDER_URL_5) {
+  const chainId = ChainId.GOERLI;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_5],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment on goerli
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x3C8a21099C202003Ec6f050Eb24F8f24a3828Ad3",
+  };
+}
+
+if (process.env.REACT_APP_PROVIDER_URL_10) {
+  const chainId = ChainId.OPTIMISM;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_10],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment on this chain
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x56e2d1b8C7dE8D11B282E1b4C924C32D91f9102B",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x255483434aba5a75dc60c1391bB162BCd9DE2882",
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_82) {
+  const chainId = ChainId.METER;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_82],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment on this chain
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xd8343E437B946D40e4C53ce1e6fF39F64F334C36",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x31C222e0D862827137ab5D4e8EE30c41Cc915a96",
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_100) {
+  const chainId = ChainId.XDAI;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_100],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny or v2 deployment on this chain
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xd2ecb3afe598b746F8123CaE365a598DA831A449",
+  };
+}
 if (process.env.REACT_APP_PROVIDER_URL_137) {
+  const chainId = ChainId.POLYGON;
+  const chain = CHAINS[chainId];
   const config: oracle.types.state.PartialChainConfig = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137],
-    nativeCurrency: CHAINS[polygonChainId].nativeCurrency,
-    chainName: CHAINS[polygonChainId].name,
-    blockExplorerUrls: [CHAINS[polygonChainId].explorerUrl],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment on this chain
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xBb1A8db2D4350976a11cdfA60A1d43f97710Da49",
     // polygon mainnet does not have requests before this block
     earliestBlockNumber: 20000000,
     // this value was selected with testing to give a balance between quantity of requests found vs how fast the latest
     // requests show removing this will enable the client to query the full range in one request.
     maxEventRangeQuery: 200000,
   };
-  optimisticChains[polygonChainId] = { ...config };
 
-  optimisticV2Chains[polygonChainId] = {
+  optimisticV2Chains[chainId] = {
     ...config,
+    optimisticOracleAddress: "0xee3afe347d5c74317041e2618c49534daf887c24",
     earliestBlockNumber: 30900000,
     maxEventRangeQuery: 200000,
   };
 }
 
-if (process.env.REACT_APP_PROVIDER_URL_42) {
-  optimisticChains[kovanChainId] = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42],
-    nativeCurrency: CHAINS[kovanChainId].nativeCurrency,
-    chainName: CHAINS[kovanChainId].name,
-    blockExplorerUrls: [CHAINS[kovanChainId].explorerUrl],
-  };
-}
-
 if (process.env.REACT_APP_PROVIDER_URL_288) {
-  optimisticChains[bobaChainId] = {
+  const chainId = ChainId.BOBA;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
     rpcUrls: [process.env.REACT_APP_PROVIDER_URL_288],
-    nativeCurrency: CHAINS[bobaChainId].nativeCurrency,
-    chainName: CHAINS[bobaChainId].name,
-    blockExplorerUrls: [CHAINS[bobaChainId].explorerUrl],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x7da554228555C8Bf3748403573d48a2138C6b848",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xb2b5C1b17B19d92CC4fC1f026B2133259e3ccd41",
   };
 }
 
-if (process.env.REACT_APP_PROVIDER_URL_5) {
+if (process.env.REACT_APP_PROVIDER_URL_416) {
+  const chainId = ChainId.SX;
+  const chain = CHAINS[chainId];
   const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_5],
-    nativeCurrency: CHAINS[goerliChainId].nativeCurrency,
-    chainName: CHAINS[goerliChainId].name,
-    blockExplorerUrls: [CHAINS[goerliChainId].explorerUrl],
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_416],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
   };
-  optimisticChains[goerliChainId] = {
+  // no skinny deployment
+  optimisticChains[chainId] = {
     ...config,
-    // sdk currently does not have a default address for chain 5, so manually provide in config
-    optimisticOracleAddress: "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
+    optimisticOracleAddress: "0x273CAC5468b7c50B9ab2ce598693c5f441750CC4",
   };
-  optimisticV2Chains[goerliChainId] = config;
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x28077B47Cd03326De7838926A63699849DD4fa87",
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_9001) {
+  const chainId = ChainId.EVMOS;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_9001],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xd2ecb3afe598b746F8123CaE365a598DA831A449",
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_42161) {
+  const chainId = ChainId.ARBITRUM;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42161],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x031A7882cE3e8b4462b057EBb0c3F23Cd731D234",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x88Ad27C41AD06f01153E7Cd9b10cBEdF4616f4d5",
+  };
+}
+if (process.env.REACT_APP_PROVIDER_URL_43114) {
+  const chainId = ChainId.AVAX;
+  const chain = CHAINS[chainId];
+  const config: oracle.types.state.PartialChainConfig = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_43114],
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl],
+  };
+  // no skinny deployment
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xB0D89D3218374BD8FE60f5748a880e9E373fB818",
+  };
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x28077B47Cd03326De7838926A63699849DD4fa87",
+  };
 }
 
 // order of export is important, this determines the order in which clients are returned from factory

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -10,14 +10,17 @@ const optimisticV2Chains: Record<
   oracle.types.state.PartialChainConfig
 > = {};
 
+// typescript doesnt believe that [string] is compatible with [string, ...string[]], so we have to cast some parts of our config
+type RequiredStringList = [string, ...string[]];
+
 // enable local node if debug is on, this only works as a fork of mainnet
-if (process.env.REACT_APP_DEBUG) {
+if (process.env.REACT_APP_FORK_1) {
   const chainId = ChainId.MM_TESTNET;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: ["http://127.0.0.1:8545"],
+  const config = {
+    rpcUrls: ["http://127.0.0.1:8545"] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
     chainName: chain.name,
   };
   optimisticChains[chainId] = {
@@ -40,11 +43,11 @@ if (process.env.REACT_APP_DEBUG) {
 if (process.env.REACT_APP_PROVIDER_URL_1) {
   const chainId = ChainId.MAINNET;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_1] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   optimisticChains[chainId] = {
     ...config,
@@ -63,11 +66,11 @@ if (process.env.REACT_APP_PROVIDER_URL_1) {
 if (process.env.REACT_APP_PROVIDER_URL_5) {
   const chainId = ChainId.GOERLI;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_5],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_5] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment on goerli
   optimisticChains[chainId] = {
@@ -76,18 +79,18 @@ if (process.env.REACT_APP_PROVIDER_URL_5) {
   };
   optimisticV2Chains[chainId] = {
     ...config,
-    optimisticOracleAddress: "0x3C8a21099C202003Ec6f050Eb24F8f24a3828Ad3",
+    optimisticOracleAddress: "0xA5B9d8a0B0Fa04Ba71BDD68069661ED5C0848884",
   };
 }
 
 if (process.env.REACT_APP_PROVIDER_URL_10) {
   const chainId = ChainId.OPTIMISM;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_10],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_10] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment on this chain
   optimisticChains[chainId] = {
@@ -102,11 +105,11 @@ if (process.env.REACT_APP_PROVIDER_URL_10) {
 if (process.env.REACT_APP_PROVIDER_URL_82) {
   const chainId = ChainId.METER;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_82],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_82] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment on this chain
   optimisticChains[chainId] = {
@@ -121,11 +124,11 @@ if (process.env.REACT_APP_PROVIDER_URL_82) {
 if (process.env.REACT_APP_PROVIDER_URL_100) {
   const chainId = ChainId.XDAI;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_100],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_100] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny or v2 deployment on this chain
   optimisticChains[chainId] = {
@@ -136,11 +139,11 @@ if (process.env.REACT_APP_PROVIDER_URL_100) {
 if (process.env.REACT_APP_PROVIDER_URL_137) {
   const chainId = ChainId.POLYGON;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_137] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment on this chain
   optimisticChains[chainId] = {
@@ -164,11 +167,11 @@ if (process.env.REACT_APP_PROVIDER_URL_137) {
 if (process.env.REACT_APP_PROVIDER_URL_288) {
   const chainId = ChainId.BOBA;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_288],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_288] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment
   optimisticChains[chainId] = {
@@ -184,11 +187,11 @@ if (process.env.REACT_APP_PROVIDER_URL_288) {
 if (process.env.REACT_APP_PROVIDER_URL_416) {
   const chainId = ChainId.SX;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_416],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_416] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment
   optimisticChains[chainId] = {
@@ -203,11 +206,11 @@ if (process.env.REACT_APP_PROVIDER_URL_416) {
 if (process.env.REACT_APP_PROVIDER_URL_9001) {
   const chainId = ChainId.EVMOS;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_9001],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_9001] as RequiredStringList,
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment
   optimisticChains[chainId] = {
@@ -222,11 +225,14 @@ if (process.env.REACT_APP_PROVIDER_URL_9001) {
 if (process.env.REACT_APP_PROVIDER_URL_42161) {
   const chainId = ChainId.ARBITRUM;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42161],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_42161] as [
+      string,
+      ...string[]
+    ],
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment
   optimisticChains[chainId] = {
@@ -241,11 +247,14 @@ if (process.env.REACT_APP_PROVIDER_URL_42161) {
 if (process.env.REACT_APP_PROVIDER_URL_43114) {
   const chainId = ChainId.AVAX;
   const chain = CHAINS[chainId];
-  const config: oracle.types.state.PartialChainConfig = {
-    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_43114],
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_43114] as [
+      string,
+      ...string[]
+    ],
     nativeCurrency: chain.nativeCurrency,
     chainName: chain.name,
-    blockExplorerUrls: [chain.explorerUrl],
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
   };
   // no skinny deployment
   optimisticChains[chainId] = {

--- a/src/helpers/oracleClient.ts
+++ b/src/helpers/oracleClient.ts
@@ -9,6 +9,7 @@ type Client = oracle.client.Client;
 export const isSupportedOracleType = oracle.utils.isSupportedOracleType;
 
 export { oracle };
+
 export type { OracleType, State, Client };
 export const events = new Events();
 export const clients = oracle.factory(

--- a/src/helpers/oracleClient.ts
+++ b/src/helpers/oracleClient.ts
@@ -42,6 +42,6 @@ forEach((client) => {
 
 if (process.env.REACT_APP_DEBUG) {
   events.on("change", (index, state) => {
-    console.log("event change", index, state);
+    console.log("change", index, state);
   });
 }

--- a/src/hooks/useRequestParams.ts
+++ b/src/hooks/useRequestParams.ts
@@ -105,7 +105,7 @@ export function useRequestInputRequired(): RequestInputRequired | undefined {
       setRequestQuery(getRequestInputRequired(params));
     } catch (err) {
       if (process.env.REACT_APP_DEBUG) console.warn("Error parsing query", err);
-      if (requestQuery) setRequestQuery(undefined);
+      setRequestQuery(undefined);
     }
   }, [searchParams]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3269,25 +3269,25 @@
     "@typescript-eslint/types" "5.10.0"
     eslint-visitor-keys "^3.0.0"
 
-"@uma/contracts-frontend@^0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.11.tgz#d966be9da9312de2090acdf5860576080b987052"
-  integrity sha512-1ogKI+olhGvcc/MyUtsbMIbwW/2nIqaCbDI/v9zBZrhkTgqp6FKqQeXM+TIx0fbxROAFVZrFd0sJjzyuCmYelg==
+"@uma/contracts-frontend@^0.3.12":
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.12.tgz#f1af7914f5344f5571fa20ecd231e56b62ccd5dc"
+  integrity sha512-MIfvXHoXAdDXNzzT9vio+1PYvp0pIKiz4XkwC9XJLdpCMuPD3bGtpaHrgLX3v36FigCNRmBYFmznlDGeoiTZ/A==
 
-"@uma/contracts-node@^0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.11.tgz#ecbb7e4eb5f389a5ceef0c646653a0ae54041116"
-  integrity sha512-meRHB9YRz6DCF/0i3+IwVUwfi7gMyvJazvcWPbavFKRZzgYHSloWCOz5CL7ckYaz2OwfVupgYeCFmBltLM0B3A==
+"@uma/contracts-node@^0.3.12":
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.12.tgz#8587e1e7b976ac732b09d25cc3b6d0c9529b73dc"
+  integrity sha512-pDtu5z5WEau9n8W6TL6t/XmITBGcl4J+MNXpNPT8PomkwQS/dMBU/tc6Qlg1NTvboU/3vnpL7EaOZVZo6eq+Pw==
 
-"@uma/sdk@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.27.0.tgz#c4f25bb3d1094ac3ed35e456135d2476ef81cea9"
-  integrity sha512-vy4LHxSW+O3lYmXoFj1hk/tIlUQMY4EOxSMgPY7skk20fWPHEkzUlA/TMrDJYT5piEhfLoAA7p7SBUxV/Rzo6w==
+"@uma/sdk@^0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.27.1.tgz#79682919c484b0cf4977d3e3101a4c5f070a4003"
+  integrity sha512-BjPuH2XiQWGNyicMdP6eBPW2vvZ18bNehGEDsewhNtfjS/WdeCPLj3opVJfbkO0StSvz5TDS2ygfNB7cUYTujA==
   dependencies:
     "@google-cloud/datastore" "^6.6.0"
     "@types/lodash-es" "^4.17.5"
-    "@uma/contracts-frontend" "^0.3.11"
-    "@uma/contracts-node" "^0.3.11"
+    "@uma/contracts-frontend" "^0.3.12"
+    "@uma/contracts-node" "^0.3.12"
     axios "^0.24.0"
     bn.js "^4.11.9"
     decimal.js "^10.3.1"


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

**Motivation**
Add in support for many more chains

**Summary**
This adds support for OPTIMISM, METER, XDAI, SX, EVMOS,ARBITRUM, AVAX. Addresses are made explicit in this config to make it easy to double check for errors. All addresses were obtained from the [networks files](https://github.com/UMAprotocol/protocol/tree/master/packages/core/networks), except for goerli, which was obtained from a [yet to be merged pr](https://github.com/UMAprotocol/protocol/pull/4056). EDIT: john has provided the updated goerli addresses which no longer match this pr.

Pay special attention when reviewing to chain constants, as these had to be searched and investigated to find things like currency symbols, names, explorers.  Most currency logos are scaffolded with the eth logo, which should probably updated in a subsequent pr.  Also pay attention to oracle addresses to make sure those look correct. 

To enable or disable each chain, you must provide an rpc url for that chain in the env ( or remove to disable it).  I will add these envs to the production deployment (except for testnets). 