### PR TITLE
improve: use shorter links in oo ui

### DIFF
--- a/src/components/index/createRequestsTableCells.tsx
+++ b/src/components/index/createRequestsTableCells.tsx
@@ -92,16 +92,14 @@ function createRequestsTableCells(
         if (formattedPrice === "0.5") proposedPrice = "Indeterminate";
       }
 
+      const requestDetailsLink = `/request?transactionHash=${
+        req.requestTx
+      }&chainId=${req.chainId}&oracleType=${req.oracleType}&eventIndex=${0}`;
+
       const cells = [
         {
           size: "lg",
-          value: (
-            <StyledLink
-              to={`/request?requester=${req.requester}&identifier=${req.identifier}&ancillaryData=${req.ancillaryData}&timestamp=${req.timestamp}&chainId=${req.chainId}&oracleType=${req.oracleType}`}
-            >
-              {title}
-            </StyledLink>
-          ),
+          value: <StyledLink to={requestDetailsLink}>{title}</StyledLink>,
           cellClassName: "first-cell",
         },
         {

--- a/src/hooks/useRequestParams.ts
+++ b/src/hooks/useRequestParams.ts
@@ -14,7 +14,7 @@ const RequestInputByTransactionSs = ss.object({
   chainId: ss.string(),
   oracleType: ss.optional(ss.string()),
   transactionHash: ss.string(),
-  eventIndex: ss.string(),
+  eventIndex: ss.optional(ss.string()),
 });
 
 // query params when link specifies request details
@@ -57,7 +57,7 @@ export function getRequestInputByTransaction(
   const required = getRequestInputRequired(params);
   return {
     ...parsed,
-    eventIndex: Number(parsed.eventIndex),
+    eventIndex: Number(parsed.eventIndex || 0),
     ...required,
   };
 }


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

This changes the url linked from the index page to use the transaction hash rather than ancillary data. this is needed so we can use url shortners and copy and paste it into other places when ancillary data is too long