### PR TITLE
feat: add support for Mumbai

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ At least one of these providers should be enabled in order for the app to collec
 - REACT_APP_PROVIDER_URL_9001=Evmos Provider
 - REACT_APP_PROVIDER_URL_42161=Arbitrum Provider
 - REACT_APP_PROVIDER_URL_43114=Avalanche Provider
+- REACT_APP_PROVIDER_URL_80001=Mumbai Provider
 - REACT_APP_DEBUG=1 enable event state debugging output to console. Remove definition in production. Setting debug to 1 will also enable local hardhat testing with chain id 1337.
 - REACT_APP_FORK_1=1 enabled mainnet fork through local hardhat or other node, hard coded to http://127.0.0.1:8545 and chain 1337
 

--- a/src/constants/blockchain.ts
+++ b/src/constants/blockchain.ts
@@ -33,6 +33,7 @@ export enum ChainId {
   ARBITRUM = 42161,
   AVAX = 43114,
   HARDHAT = 31337,
+  MUMBAI = 80001,
 }
 
 // useful place to get most of this information: https://chainlist.org/
@@ -216,6 +217,19 @@ export const CHAINS: Record<ChainId, ChainMetadata> = {
     nativeCurrency: {
       name: "Avalanche",
       symbol: "AVAX",
+      decimals: 18,
+    },
+  },
+  [ChainId.MUMBAI]: {
+    name: "Mumbai Polygon",
+    chainId: ChainId.MUMBAI,
+    logoURI: polygonLogo,
+    explorerUrl: "https://mumbai.polygonscan.com",
+    constructExplorerLink: (txHash: string) =>
+      `https://mumbai.polygonscan.com/tx/${txHash}`,
+    nativeCurrency: {
+      name: "Polygon",
+      symbol: "MATIC",
       decimals: 18,
     },
   },

--- a/src/constants/oracleConfig.ts
+++ b/src/constants/oracleConfig.ts
@@ -278,6 +278,27 @@ if (process.env.REACT_APP_PROVIDER_URL_43114) {
     optimisticOracleAddress: "0x28077B47Cd03326De7838926A63699849DD4fa87",
   };
 }
+if (process.env.REACT_APP_PROVIDER_URL_80001) {
+  const chainId = ChainId.MUMBAI;
+  const chain = CHAINS[chainId];
+  ChainsEnabled.push({ label: chain.name, value: chainId.toString() });
+  const config = {
+    rpcUrls: [process.env.REACT_APP_PROVIDER_URL_80001] as RequiredStringList,
+    nativeCurrency: chain.nativeCurrency,
+    chainName: chain.name,
+    blockExplorerUrls: [chain.explorerUrl] as RequiredStringList,
+  };
+  // no skinny deployment on this chain
+  optimisticChains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0xAB75727d4e89A7f7F04f57C00234a35950527115",
+  };
+
+  optimisticV2Chains[chainId] = {
+    ...config,
+    optimisticOracleAddress: "0x60E6140330F8FE31e785190F39C1B5e5e833c2a9",
+  };
+}
 
 // order of export is important, this determines the order in which clients are returned from factory
 const config: [


### PR DESCRIPTION
This PR adds support for mumbai. A few hackathon teams have asked for mumbai support along with Polymarket using mumbai for testing.

When I tested I included the rpc url as an env variable but is there any action needed to include in vercel deployment?