### PR TITLE
improve: add explanation to zodiac proposals

### DIFF
--- a/src/components/request/useRequestTableData.tsx
+++ b/src/components/request/useRequestTableData.tsx
@@ -42,7 +42,7 @@ function useRequestTableData({
 }: UseRequestTableParams) {
   const [rows, setRows] = useState<IRow[]>([]);
   const [headerCells] = useState<ICell[]>(hc);
-  const { rules } = useOptimisticGovernorRules();
+  const { rules, explanation } = useOptimisticGovernorRules();
 
   useEffect(() => {
     const nextRows = [] as IRow[];
@@ -273,6 +273,29 @@ function useRequestTableData({
         ],
       });
     }
+
+    if (explanation !== undefined) {
+      nextRows.push({
+        cells: [
+          {
+            size: "xs",
+            value: "8",
+          },
+          {
+            size: "sm",
+            value: "explanation",
+          },
+          {
+            size: "sm",
+            value: "string",
+          },
+          {
+            size: "lg",
+            value: explanation,
+          },
+        ],
+      });
+    }
     setRows(nextRows);
   }, [
     chainId,
@@ -282,6 +305,7 @@ function useRequestTableData({
     ancillaryData,
     requestTxHash,
     rules,
+    explanation,
   ]);
 
   return { rows, headerCells };

--- a/src/hooks/useOptimisticGovernorRules.ts
+++ b/src/hooks/useOptimisticGovernorRules.ts
@@ -4,25 +4,15 @@ import useReader from "hooks/useOracleReader";
 import { ethers } from "ethers";
 
 const ogAbi = [
-  {
-    inputs: [],
-    name: "rules",
-    outputs: [
-      {
-        internalType: "string",
-        name: "",
-        type: "string",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
+  "function rules() view returns (string)",
+  "function proposeTransactions(tuple(address to, uint8 operation, uint256 value, bytes data)[] _transactions, bytes _explanation)",
 ];
 
 export function useOptimisticGovernorRules() {
   const { state } = useClient();
-  const { provider, requester } = useReader(state);
+  const { provider, requester, proposeTx } = useReader(state);
   const [rules, setRules] = useState<undefined | string>();
+  const [explanation, setExplanation] = useState<undefined | string>();
 
   useEffect(() => {
     if (requester === undefined) return;
@@ -41,5 +31,28 @@ export function useOptimisticGovernorRules() {
     getRules();
   }, [requester, provider]);
 
-  return { rules };
+  useEffect(() => {
+    async function getExplanation() {
+      if (rules === undefined) return;
+      if (provider === undefined) return;
+      if (proposeTx === undefined) return;
+      try {
+        const proposeData = await provider.getTransaction(proposeTx);
+        if (proposeData?.data !== undefined) {
+          const iface = new ethers.utils.Interface(ogAbi);
+          const decodedTransaction = iface.decodeFunctionData(
+            "proposeTransactions",
+            proposeData.data
+          );
+          setExplanation(decodedTransaction[1]);
+        }
+      } catch (error) {
+        setExplanation(undefined);
+        console.error(`Get explanation failed: ${error}`);
+      }
+    }
+    getExplanation();
+  }, [proposeTx, provider, rules]);
+
+  return { rules, explanation };
 }

--- a/src/hooks/useOptimisticGovernorRules.ts
+++ b/src/hooks/useOptimisticGovernorRules.ts
@@ -5,8 +5,59 @@ import { ethers } from "ethers";
 import { toUtf8String } from "ethers/lib/utils";
 
 const ogAbi = [
-  "function rules() view returns (string)",
-  "function proposeTransactions(tuple(address to, uint8 operation, uint256 value, bytes data)[] _transactions, bytes _explanation)",
+  {
+    inputs: [],
+    name: "rules",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "to",
+            type: "address",
+          },
+          {
+            internalType: "enum Enum.Operation",
+            name: "operation",
+            type: "uint8",
+          },
+          {
+            internalType: "uint256",
+            name: "value",
+            type: "uint256",
+          },
+          {
+            internalType: "bytes",
+            name: "data",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct OptimisticGovernor.Transaction[]",
+        name: "_transactions",
+        type: "tuple[]",
+      },
+      {
+        internalType: "bytes",
+        name: "_explanation",
+        type: "bytes",
+      },
+    ],
+    name: "proposeTransactions",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
 ];
 
 export function useOptimisticGovernorRules() {
@@ -16,8 +67,10 @@ export function useOptimisticGovernorRules() {
   const [explanation, setExplanation] = useState<undefined | string>();
 
   useEffect(() => {
-    if (requester === undefined) return;
-    if (provider === undefined) return;
+    if (requester === undefined || provider === undefined) {
+      setRules(undefined);
+      return;
+    }
 
     async function getRules() {
       try {
@@ -34,9 +87,15 @@ export function useOptimisticGovernorRules() {
 
   useEffect(() => {
     async function getExplanation() {
-      if (rules === undefined) return;
-      if (provider === undefined) return;
-      if (proposeTx === undefined) return;
+      if (
+        rules === undefined ||
+        provider === undefined ||
+        proposeTx === undefined
+      ) {
+        setExplanation(undefined);
+        return;
+      }
+
       try {
         const proposeData = await provider.getTransaction(proposeTx);
         if (proposeData?.data !== undefined) {

--- a/src/hooks/useOptimisticGovernorRules.ts
+++ b/src/hooks/useOptimisticGovernorRules.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import useClient from "hooks/useOracleClient";
 import useReader from "hooks/useOracleReader";
 import { ethers } from "ethers";
+import { toUtf8String } from "ethers/lib/utils";
 
 const ogAbi = [
   "function rules() view returns (string)",
@@ -44,7 +45,7 @@ export function useOptimisticGovernorRules() {
             "proposeTransactions",
             proposeData.data
           );
-          setExplanation(decodedTransaction[1]);
+          setExplanation(toUtf8String(decodedTransaction[1]));
         }
       } catch (error) {
         setExplanation(undefined);

--- a/src/hooks/useOptimisticGovernorRules.ts
+++ b/src/hooks/useOptimisticGovernorRules.ts
@@ -5,59 +5,8 @@ import { ethers } from "ethers";
 import { toUtf8String } from "ethers/lib/utils";
 
 const ogAbi = [
-  {
-    inputs: [],
-    name: "rules",
-    outputs: [
-      {
-        internalType: "string",
-        name: "",
-        type: "string",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        components: [
-          {
-            internalType: "address",
-            name: "to",
-            type: "address",
-          },
-          {
-            internalType: "enum Enum.Operation",
-            name: "operation",
-            type: "uint8",
-          },
-          {
-            internalType: "uint256",
-            name: "value",
-            type: "uint256",
-          },
-          {
-            internalType: "bytes",
-            name: "data",
-            type: "bytes",
-          },
-        ],
-        internalType: "struct OptimisticGovernor.Transaction[]",
-        name: "_transactions",
-        type: "tuple[]",
-      },
-      {
-        internalType: "bytes",
-        name: "_explanation",
-        type: "bytes",
-      },
-    ],
-    name: "proposeTransactions",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
+  "function rules() view returns (string)",
+  "function proposeTransactions(tuple(address to, uint8 operation, uint256 value, bytes data)[] _transactions, bytes _explanation)",
 ];
 
 export function useOptimisticGovernorRules() {


### PR DESCRIPTION
Signed-off-by: Alex Gaines <againes@umaproject.org>

This PR includes the `explanation` for Zodiac proposals. For Snapshot proposals, the IPFS hash is included as the explanation which can be used as a unique identifier for proposals. Including it in the OO UI will make the verification process easier.